### PR TITLE
Apb 1865: Add 'use by' date to 'invitation complete' pageAdd 'use by' date to 'invitation complete' page

### DIFF
--- a/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentsInvitationController.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentsInvitationController.scala
@@ -129,10 +129,11 @@ class AgentsInvitationController @Inject()(
     invitationsService
       .createInvitation(arn, userInput)
       .map(invitation => {
-        if(invitation.service == "HMRC-MTD-IT") auditService.sendAgentInvitationSubmitted(arn, invitation.id, userInput, "Success")
-        else auditService.sendAgentInvitationSubmitted(arn, invitation.id, userInput, "Not Required")
+        val id = extractInvitationId(invitation.selfUrl.toString)
+        if(invitation.service == "HMRC-MTD-IT") auditService.sendAgentInvitationSubmitted(arn, id, userInput, "Success")
+        else auditService.sendAgentInvitationSubmitted(arn, id, userInput, "Not Required")
         Redirect(routes.AgentsInvitationController.invitationSent).withSession(
-          request.session + ("invitationId" -> invitation.id) + ("deadline" -> invitation.expiryDate.toString(DateTimeFormat.longDate()))
+          request.session + ("invitationId" -> id) + ("deadline" -> invitation.expiryDate.toString(DateTimeFormat.longDate()))
         )
       })
       .recoverWith {

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentsInvitationController.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentsInvitationController.scala
@@ -16,9 +16,9 @@
 
 package uk.gov.hmrc.agentinvitationsfrontend.controllers
 
-import java.net.URL
 import javax.inject.{Inject, Named, Singleton}
 
+import org.joda.time.format.DateTimeFormat
 import play.api.Configuration
 import play.api.data.Form
 import play.api.data.Forms._
@@ -104,7 +104,6 @@ class AgentsInvitationController @Inject()(
     withAuthorisedAsAgent { arn =>
       val maybeNino = request.session.get("nino")
       val maybeService = request.session.get("service")
-
       (maybeNino, maybeService) match {
         case (Some(nino), Some(service)) =>
           Future successful Ok(enter_postcode(agentInvitationPostCodeForm.fill(AgentInvitationUserInput(Nino(nino), Some(service), None))))
@@ -130,10 +129,11 @@ class AgentsInvitationController @Inject()(
     invitationsService
       .createInvitation(arn, userInput)
       .map(invitation => {
-        val id = extractInvitationId(invitation.selfUrl.toString)
-        if(invitation.service == "HMRC-MTD-IT") auditService.sendAgentInvitationSubmitted(arn, id, userInput, "Success")
-        else auditService.sendAgentInvitationSubmitted(arn, id, userInput, "Not Required")
-        Redirect(routes.AgentsInvitationController.invitationSent).withSession(request.session + ("invitationId" -> id))
+        if(invitation.service == "HMRC-MTD-IT") auditService.sendAgentInvitationSubmitted(arn, invitation.id, userInput, "Success")
+        else auditService.sendAgentInvitationSubmitted(arn, invitation.id, userInput, "Not Required")
+        Redirect(routes.AgentsInvitationController.invitationSent).withSession(
+          request.session + ("invitationId" -> invitation.id) + ("deadline" -> invitation.expiryDate.toString(DateTimeFormat.longDate()))
+        )
       })
       .recoverWith {
         case noMtdItId: Upstream4xxResponse if noMtdItId.message.contains("CLIENT_REGISTRATION_NOT_FOUND") => {
@@ -152,11 +152,11 @@ class AgentsInvitationController @Inject()(
 
   def invitationSent: Action[AnyContent] = Action.async { implicit request =>
     withAuthorisedAsAgent { arn =>
-      request.session.get("invitationId") match {
-        case Some(id) =>
+      (request.session.get("invitationId"), request.session.get("deadline")) match {
+        case (Some(id), Some(deadline)) =>
           val invitationUrl: String = s"$externalUrl${routes.ClientsInvitationController.start(InvitationId(id)).path()}"
-          Future successful Ok(invitation_sent(invitationUrl, asAccUrl.toString))
-        case None => throw new RuntimeException("User attempted to browse to invitationSent")
+          Future successful Ok(invitation_sent(invitationUrl, asAccUrl.toString, deadline))
+        case _ => throw new RuntimeException("User attempted to browse to invitationSent")
       }
     }
   }

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/models/Invitation.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/models/Invitation.scala
@@ -18,19 +18,21 @@ package uk.gov.hmrc.agentinvitationsfrontend.models
 
 import java.net.URL
 
-import org.joda.time.DateTime
-import play.api.libs.json.{ JsPath, Reads }
+import org.joda.time.{DateTime, LocalDate}
+import play.api.libs.json.{JsPath, Reads}
 import uk.gov.hmrc.agentmtdidentifiers.model.Arn
 import uk.gov.hmrc.domain.SimpleObjectReads
 import play.api.libs.functional.syntax._
 
 case class Invitation(
+  id: String,
   arn: Arn,
   service: String,
   clientId: String,
   status: String,
   created: DateTime,
   lastUpdated: DateTime,
+  expiryDate: LocalDate,
   selfUrl: URL,
   acceptUrl: Option[URL],
   rejectUrl: Option[URL])
@@ -41,12 +43,14 @@ object Invitation {
   def reads(readingFrom: URL): Reads[Invitation] = {
     implicit val urlReads = new SimpleObjectReads[URL]("href", s => new URL(readingFrom, s))
     (
+      (JsPath \ "id").read[String] and
       (JsPath \ "arn").read[Arn] and
       (JsPath \ "service").read[String] and
       (JsPath \ "clientId").read[String] and
       (JsPath \ "status").read[String] and
       (JsPath \ "created").read[DateTime] and
       (JsPath \ "lastUpdated").read[DateTime] and
+      (JsPath \ "expiryDate").read[LocalDate] and
       (JsPath \ "_links" \ "self").read[URL] and
       (JsPath \ "_links" \ "accept").readNullable[URL] and
       (JsPath \ "_links" \ "reject").readNullable[URL])(Invitation.apply _)

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/models/Invitation.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/models/Invitation.scala
@@ -25,7 +25,6 @@ import uk.gov.hmrc.domain.SimpleObjectReads
 import play.api.libs.functional.syntax._
 
 case class Invitation(
-  id: String,
   arn: Arn,
   service: String,
   clientId: String,
@@ -43,7 +42,6 @@ object Invitation {
   def reads(readingFrom: URL): Reads[Invitation] = {
     implicit val urlReads = new SimpleObjectReads[URL]("href", s => new URL(readingFrom, s))
     (
-      (JsPath \ "id").read[String] and
       (JsPath \ "arn").read[Arn] and
       (JsPath \ "service").read[String] and
       (JsPath \ "clientId").read[String] and

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/services/InvitationsService.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/services/InvitationsService.scala
@@ -31,8 +31,6 @@ class InvitationsService @Inject() (invitationsConnector: InvitationsConnector,
                                     agentServicesAccountConnector: AgentServicesAccountConnector) {
 
   def createInvitation(arn: Arn, userInput: AgentInvitationUserInput)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Invitation] = {
-
-    //TODO Handle No Postcode for AFI Journey
     val service = userInput.service.getOrElse(throw new Exception("Service is missing"))
     val agentInvitation = AgentInvitation(service, "ni", userInput.nino.value, userInput.postcode)
 

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/views/agents/invitation_sent.scala.html
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/views/agents/invitation_sent.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import play.api.Configuration
-@(invitationUrl: String, agentServicesAcUrl: String)(implicit request: Request[_], messages: Messages, configuration: Configuration)
+@(invitationUrl: String, agentServicesAcUrl: String, deadline: String)(implicit request: Request[_], messages: Messages, configuration: Configuration)
 
 @uk.gov.hmrc.agentinvitationsfrontend.views.html.main_template(title = Messages("invitation-sent-link.title"), bodyClasses = None) {
 
@@ -27,8 +27,9 @@
   </div>
 
   <h2 class="heading-medium">@Messages("invitation-sent.header")</h2>
-  <p>@Html(Messages("invitation-sent.description.advice.pt1"))</p>
+  <p>@Html(Messages("invitation-sent.description.advice.pt1", deadline))</p>
   <p>@Html(Messages("invitation-sent.description.advice.pt2"))</p>
+  <p>@Html(Messages("invitation-sent.description.advice.pt3"))</p>
 
   <a href="@agentServicesAcUrl/agent-services-account" class="button" id="continue" role="button">@Messages("invitation-sent.button")</a>
 }

--- a/conf/messages
+++ b/conf/messages
@@ -28,8 +28,9 @@ continue.button=Continue
 # Invitation Sent
 invitation-sent-link.title=Send your client this link
 invitation-sent.header=What to do next
-invitation-sent.description.advice.pt1=You must <strong>share this unique link</strong> with your client by copying and pasting it into an email.
-invitation-sent.description.advice.pt2=This is the only way your client can authorise you. <strong>HMRC will not share the link for you.</strong>
+invitation-sent.description.advice.pt1=You must <strong>share this unique link</strong> with your client and they must respond by {0}
+invitation-sent.description.advice.pt2=Copy and pasting it into an email. If your client does not respond in time, you will need to request authorisation again and send them the new link.
+invitation-sent.description.advice.pt3=This is the only way your client can authorise you. <strong>HMRC will not share the link for you.</strong>
 invitation-sent.button=Return to your account
 
 # Not Enrolled

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/connectors/AgentServicesAccountConnectorISpec.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/connectors/AgentServicesAccountConnectorISpec.scala
@@ -4,7 +4,7 @@ import uk.gov.hmrc.agentinvitationsfrontend.support.BaseISpec
 import uk.gov.hmrc.agentmtdidentifiers.model.Arn
 import uk.gov.hmrc.http.{HeaderCarrier, NotFoundException}
 
-class AgentServicesAccountConnectorISpec  extends BaseISpec {
+class AgentServicesAccountConnectorISpec extends BaseISpec {
 
   implicit val hc = HeaderCarrier()
   val connector = app.injector.instanceOf[AgentServicesAccountConnector]

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/connectors/InvitationsConnectorISpec.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/connectors/InvitationsConnectorISpec.scala
@@ -1,7 +1,7 @@
 package uk.gov.hmrc.agentinvitationsfrontend.connectors
 
 import uk.gov.hmrc.agentinvitationsfrontend.UriPathEncoding._
-import uk.gov.hmrc.agentinvitationsfrontend.models.AgentInvitation
+import uk.gov.hmrc.agentinvitationsfrontend.models.{AgentInvitation, Invitation}
 import uk.gov.hmrc.agentinvitationsfrontend.support.BaseISpec
 import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, InvitationId, MtdItId}
 import uk.gov.hmrc.domain.Nino

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentInvitationControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentInvitationControllerISpec.scala
@@ -16,6 +16,7 @@ package uk.gov.hmrc.agentinvitationsfrontend.controllers
  * limitations under the License.
  */
 
+import org.joda.time.LocalDate
 import play.api.i18n.Messages
 import play.api.mvc.{AnyContentAsEmpty, _}
 import play.api.test.FakeRequest
@@ -141,8 +142,8 @@ class AgentInvitationControllerISpec extends BaseISpec {
     }
 
     "return 303 for authorised Agent with valid nino and Personal Income Record service, redirect to invitation sent page" in {
-      createInvitationStubForPIR(arn, mtdItId.value, invitationId, validNino.value, "", servicePIR, "NI")
-      getInvitationStub(arn, mtdItId.value, invitationId, servicePIR, "NI")
+      createInvitationStubForPIR(arn, validNino.value, invitationId, validNino.value, servicePIR, "NI")
+      getInvitationStub(arn, validNino.value, invitationId, servicePIR, "NI")
 
       val serviceForm = agentInvitationServiceForm.fill(AgentInvitationUserInput(validNino, Some(servicePIR), None))
       val result = submitService(authorisedAsValidAgent(request.withFormUrlEncodedBody(serviceForm.data.toSeq: _*)
@@ -275,11 +276,14 @@ class AgentInvitationControllerISpec extends BaseISpec {
     val invitationSent = controller.invitationSent()
 
     "return 200 for authorised Agent with valid postcode and redirected to Confirm Invitation Page (secureFlag = false)" in {
-      val result = invitationSent(authorisedAsValidAgent(request.withSession("invitationId" -> "ABERULMHCKKW3"), arn.value))
+      val result = invitationSent(authorisedAsValidAgent(request.withSession("invitationId" -> "ABERULMHCKKW3", "deadline" -> "27 December 2017"), arn.value))
 
       status(result) shouldBe 200
       checkHtmlResultWithBodyText(result, htmlEscapedMessage("invitation-sent-link.title"))
       checkHtmlResultWithBodyText(result, htmlEscapedMessage("invitation-sent.header"))
+      checkHtmlResultWithBodyText(result, hasMessage("invitation-sent.description.advice.pt1", "27 December 2017"))
+      checkHtmlResultWithBodyText(result, htmlEscapedMessage("invitation-sent.description.advice.pt2"))
+      checkHtmlResultWithBodyText(result, hasMessage("invitation-sent.description.advice.pt3"))
       checkHtmlResultWithBodyText(result, htmlEscapedMessage("invitation-sent.button"))
       checkHtmlResultWithBodyText(result, htmlEscapedMessage(s"$wireMockBaseUrlAsString${routes.ClientsInvitationController.start(invitationId)}"))
       checkHtmlResultWithBodyText(result, wireMockBaseUrlAsString)

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentInvitationControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentInvitationControllerISpec.scala
@@ -290,7 +290,7 @@ class AgentInvitationControllerISpec extends BaseISpec {
       verifyAuthoriseAttempt()
     }
 
-    "return exception when no invitation id found in session" in {
+    "return exception when no invitation id and deadline found in session" in {
       val result = invitationSent(authorisedAsValidAgent(request, arn.value))
 
       an[RuntimeException] should be thrownBy await(result)

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/ClientsInvitationControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/ClientsInvitationControllerISpec.scala
@@ -35,6 +35,7 @@ class ClientsInvitationControllerISpec extends BaseISpec {
   val invalidInvitationIdCRC5 = InvitationId("ABERULMHCKKW1")
   val serviceITSA = "HMRC-MTD-IT"
   val serviceNI = "HMRC-NI"
+  val servicePIR = "PERSONAL-INCOME-RECORD"
   val identifierITSA = "MTDITID"
   val identifierAFI = "NI"
   val nino = "AB123456A"
@@ -102,7 +103,7 @@ class ClientsInvitationControllerISpec extends BaseISpec {
 
     "show invitation_declined page for an authenticated client with a valid invitation for AFI" in {
 
-      getInvitationStub(arn, nino, invitationIdAFI, serviceNI, identifierAFI)
+      getInvitationStub(arn, nino, invitationIdAFI, servicePIR, identifierAFI)
       rejectInvitationStub(nino, invitationIdAFI, identifierAFI)
       givenGetAgencyNameStub(arn)
 
@@ -118,7 +119,7 @@ class ClientsInvitationControllerISpec extends BaseISpec {
 
     "redirect to invitationAlreadyResponded when declined a invitation that is already actioned" in {
       getInvitationStub(arn, mtdItId.value, invitationIdITSA, serviceITSA, identifierITSA)
-      getInvitationStub(arn, nino, invitationIdAFI, serviceNI, identifierAFI)
+      getInvitationStub(arn, nino, invitationIdAFI, servicePIR, identifierAFI)
       alreadyActionedRejectInvitationStub(mtdItId.value, invitationIdITSA, identifierITSA)
       alreadyActionedRejectInvitationStub(nino, invitationIdAFI, identifierAFI)
       givenGetAgencyNameStub(arn)
@@ -172,7 +173,7 @@ class ClientsInvitationControllerISpec extends BaseISpec {
 
     "return exception when agency name retrieval fails" in {
       getInvitationStub(arn, mtdItId.value, invitationIdITSA, serviceITSA, identifierITSA)
-      getInvitationStub(arn, nino, invitationIdAFI, serviceNI, identifierAFI)
+      getInvitationStub(arn, nino, invitationIdAFI, servicePIR, identifierAFI)
       givenAgencyNameNotFoundStub(arn)
 
       val resultITSA = getInvitationDeclinedITSA(authorisedAsValidClientITSA(FakeRequest().withSession("invitationId" -> invitationIdITSA.value), mtdItId.value))
@@ -199,7 +200,7 @@ class ClientsInvitationControllerISpec extends BaseISpec {
     }
 
     "show the confirm invitation page for AFI" in {
-      getInvitationStub(arn, nino, invitationIdAFI, serviceNI, "NI")
+      getInvitationStub(arn, nino, invitationIdAFI, servicePIR, "NI")
       givenGetAgencyNameStub(arn)
       val result = getConfirmInvitationAFI(authorisedAsValidClientAFI(FakeRequest().withSession("invitationId" -> invitationIdAFI.value), nino))
       verifyAgentInvitationResponseEvent(invitationIdAFI, arn.value, "Accepted", nino, serviceNI, "My Agency")
@@ -248,7 +249,7 @@ class ClientsInvitationControllerISpec extends BaseISpec {
 
     "redirect to invitationAlreadyResponded when an invitation is returned that is already actioned" in {
       getAlreadyAcceptedInvitationStub(arn, mtdItId.value, invitationIdITSA, serviceITSA, identifierITSA)
-      getAlreadyAcceptedInvitationStub(arn, nino, invitationIdAFI, serviceNI, identifierAFI)
+      getAlreadyAcceptedInvitationStub(arn, nino, invitationIdAFI, servicePIR, identifierAFI)
       val resultITSA = getConfirmInvitationITSA(authorisedAsValidClientITSA(FakeRequest().withSession("invitationId" -> invitationIdITSA.value), mtdItId.value))
       val resultAFI = getConfirmInvitationAFI(authorisedAsValidClientAFI(FakeRequest().withSession("invitationId" -> invitationIdAFI.value), nino))
 
@@ -290,7 +291,7 @@ class ClientsInvitationControllerISpec extends BaseISpec {
 
     "reshow the page when neither yes nor no choices were selected with an error message" in {
       getInvitationStub(arn, mtdItId.value, invitationIdITSA, serviceITSA, identifierITSA)
-      getInvitationStub(arn, nino, invitationIdAFI, serviceNI, identifierAFI)
+      getInvitationStub(arn, nino, invitationIdAFI, servicePIR, identifierAFI)
       givenGetAgencyNameStub(arn)
       val resultITSA = submitConfirmInvitationITSA(authorisedAsValidClientITSA(FakeRequest().withSession("invitationId" -> invitationIdITSA.value), mtdItId.value))
       val resultAFI = submitConfirmInvitationAFI(authorisedAsValidClientAFI(FakeRequest().withSession("invitationId" -> invitationIdAFI.value), nino))
@@ -305,7 +306,7 @@ class ClientsInvitationControllerISpec extends BaseISpec {
 
     "redirect to confirm terms page when yes was selected" in {
       getInvitationStub(arn, mtdItId.value, invitationIdITSA, serviceITSA, identifierITSA)
-      getInvitationStub(arn, nino, invitationIdAFI, serviceNI, identifierAFI)
+      getInvitationStub(arn, nino, invitationIdAFI, servicePIR, identifierAFI)
       givenGetAgencyNameStub(arn)
 
       val reqITSA = authorisedAsValidClientITSA(FakeRequest().withSession("invitationId" -> invitationIdITSA.value), mtdItId.value).withFormUrlEncodedBody("confirmInvite" -> "true")
@@ -321,7 +322,7 @@ class ClientsInvitationControllerISpec extends BaseISpec {
 
     "redirect to invitation declined when no is selected" in {
       getInvitationStub(arn, mtdItId.value, invitationIdITSA, serviceITSA, identifierITSA)
-      getInvitationStub(arn, nino, invitationIdAFI, serviceNI, identifierAFI)
+      getInvitationStub(arn, nino, invitationIdAFI, servicePIR, identifierAFI)
       givenGetAgencyNameStub(arn)
 
       val reqITSA = authorisedAsValidClientITSA(FakeRequest().withSession("invitationId" -> invitationIdITSA.value), mtdItId.value).withFormUrlEncodedBody("confirmInvite" -> "false")
@@ -337,7 +338,7 @@ class ClientsInvitationControllerISpec extends BaseISpec {
 
     "return exception when agency name retrieval fails" in {
       getInvitationStub(arn, mtdItId.value, invitationIdITSA, serviceITSA, identifierITSA)
-      getInvitationStub(arn, nino, invitationIdAFI, serviceNI, identifierAFI)
+      getInvitationStub(arn, nino, invitationIdAFI, servicePIR, identifierAFI)
       givenAgencyNameNotFoundStub(arn)
 
       val resultITSA = submitConfirmInvitationITSA(authorisedAsValidClientITSA(FakeRequest().withSession("invitationId" -> invitationIdITSA.value), mtdItId.value))
@@ -355,7 +356,7 @@ class ClientsInvitationControllerISpec extends BaseISpec {
 
     "show the confirm terms page for ITSA" in {
       getInvitationStub(arn, mtdItId.value, invitationIdITSA, serviceITSA, identifierITSA)
-      getInvitationStub(arn, nino, invitationIdAFI, serviceNI, identifierAFI)
+      getInvitationStub(arn, nino, invitationIdAFI, servicePIR, identifierAFI)
       givenGetAgencyNameStub(arn)
       val reqITSA = authorisedAsValidClientITSA(FakeRequest().withSession("invitationId" -> invitationIdITSA.value), mtdItId.value)
       val reqAFI = authorisedAsValidClientAFI(FakeRequest().withSession("invitationId" -> invitationIdAFI.value), nino)
@@ -369,7 +370,7 @@ class ClientsInvitationControllerISpec extends BaseISpec {
     }
 
     "show the confirm terms page for AFI" in {
-      getInvitationStub(arn, nino, invitationIdAFI, serviceNI, "NI")
+      getInvitationStub(arn, nino, invitationIdAFI, servicePIR, identifierAFI)
       givenGetAgencyNameStub(arn)
       val req = authorisedAsValidClientAFI(FakeRequest().withSession("invitationId" -> invitationIdAFI.value), nino)
       val result = getConfirmTermsAFI(req)
@@ -381,8 +382,8 @@ class ClientsInvitationControllerISpec extends BaseISpec {
     }
 
     "show the invitation expired page when invitation has expired" in {
-      getExpiredInvitationStub(arn, mtdItId.value, invitationIdITSA)
-      getExpiredInvitationStub(arn, nino, invitationIdAFI)
+      getExpiredInvitationStub(arn, mtdItId.value, invitationIdITSA, serviceITSA, identifierITSA)
+      getExpiredInvitationStub(arn, nino, invitationIdAFI, servicePIR, identifierAFI)
       givenGetAgencyNameStub(arn)
       val reqITSA = authorisedAsValidClientITSA(FakeRequest().withSession("invitationId" -> invitationIdITSA.value), mtdItId.value)
       val reqAFI = authorisedAsValidClientAFI(FakeRequest().withSession("invitationId" -> invitationIdAFI.value), nino)
@@ -412,7 +413,7 @@ class ClientsInvitationControllerISpec extends BaseISpec {
 
     "redirect to complete page when the checkbox was checked" in {
       getInvitationStub(arn, mtdItId.value, invitationIdITSA, serviceITSA, identifierITSA)
-      getInvitationStub(arn, nino, invitationIdAFI, serviceNI, identifierAFI)
+      getInvitationStub(arn, nino, invitationIdAFI, servicePIR, identifierAFI)
       acceptInvitationStub(mtdItId.value, invitationIdITSA, identifierITSA)
       acceptInvitationStub(nino, invitationIdAFI, identifierAFI)
       givenGetAgencyNameStub(arn)
@@ -430,7 +431,7 @@ class ClientsInvitationControllerISpec extends BaseISpec {
 
     "call agent-client-authorisation to accept the invitation and create the relationship in ETMP when the checkbox was checked" in {
       getInvitationStub(arn, mtdItId.value, invitationIdITSA, serviceITSA, identifierITSA)
-      getInvitationStub(arn, nino, invitationIdAFI, serviceNI, identifierAFI)
+      getInvitationStub(arn, nino, invitationIdAFI, servicePIR, identifierAFI)
       acceptInvitationStub(mtdItId.value, invitationIdITSA, identifierITSA)
       acceptInvitationStub(nino, invitationIdAFI, identifierAFI)
       givenGetAgencyNameStub(arn)
@@ -446,7 +447,7 @@ class ClientsInvitationControllerISpec extends BaseISpec {
 
     "reshow the page when the checkbox was not checked with an error message" in {
       getInvitationStub(arn, mtdItId.value, invitationIdITSA, serviceITSA, identifierITSA)
-      getInvitationStub(arn, nino, invitationIdAFI, serviceNI, identifierAFI)
+      getInvitationStub(arn, nino, invitationIdAFI, servicePIR, identifierAFI)
       acceptInvitationStub(mtdItId.value, invitationIdITSA, identifierITSA)
       acceptInvitationStub(nino, invitationIdAFI, identifierAFI)
       givenGetAgencyNameStub(arn)
@@ -470,7 +471,7 @@ class ClientsInvitationControllerISpec extends BaseISpec {
       val reqITSA = authorisedAsValidClientITSA(FakeRequest(), mtdItId.value).withFormUrlEncodedBody("confirmTerms" -> "true")
       val reqAFI = authorisedAsValidClientAFI(FakeRequest(), nino).withFormUrlEncodedBody("confirmTerms" -> "true")
       getInvitationStub(arn, mtdItId.value, invitationIdITSA, serviceITSA, identifierITSA)
-      getInvitationStub(arn, nino, invitationIdAFI, serviceNI, identifierAFI)
+      getInvitationStub(arn, nino, invitationIdAFI, servicePIR, identifierAFI)
       acceptInvitationNoPermissionStub(mtdItId.value, invitationIdITSA, identifierITSA)
       acceptInvitationNoPermissionStub(nino, invitationIdAFI, identifierAFI)
       val resultITSA = submitConfirmTermsITSA(reqITSA)
@@ -486,7 +487,7 @@ class ClientsInvitationControllerISpec extends BaseISpec {
       val reqITSA = authorisedAsValidClientITSA(FakeRequest(), mtdItId.value).withFormUrlEncodedBody("confirmTerms" -> "true")
       val reqAFI = authorisedAsValidClientAFI(FakeRequest(), nino).withFormUrlEncodedBody("confirmTerms" -> "true")
       getInvitationStub(arn, mtdItId.value, invitationIdITSA, serviceITSA, identifierITSA)
-      getInvitationStub(arn, nino, invitationIdAFI, serviceNI, identifierAFI)
+      getInvitationStub(arn, nino, invitationIdAFI, servicePIR, identifierAFI)
       alreadyActionedAcceptInvitationStub(mtdItId.value, invitationIdITSA, identifierITSA)
       alreadyActionedAcceptInvitationStub(nino, invitationIdAFI, identifierAFI)
       val resultITSA = submitConfirmTermsITSA(reqITSA)
@@ -539,7 +540,7 @@ class ClientsInvitationControllerISpec extends BaseISpec {
     }
 
   "show the complete page for AFI" in {
-      getInvitationStub(arn, nino, invitationIdAFI, serviceNI, identifierAFI)
+      getInvitationStub(arn, nino, invitationIdAFI, servicePIR, identifierAFI)
       givenGetAgencyNameStub(arn)
 
       val result = getCompletePageAFI(authorisedAsValidClientAFI(FakeRequest().withSession("invitationId" -> invitationIdAFI.value), nino))
@@ -553,7 +554,7 @@ class ClientsInvitationControllerISpec extends BaseISpec {
     }
 
     "return exception when agency name retrieval fails for AFI" in {
-      getInvitationStub(arn, nino, invitationIdAFI, serviceNI, identifierAFI)
+      getInvitationStub(arn, nino, invitationIdAFI, servicePIR, identifierAFI)
       givenAgencyNameNotFoundStub(arn)
       val result = getCompletePageAFI(authorisedAsValidClientAFI(FakeRequest().withSession("invitationId" -> invitationIdAFI.value), nino))
       an[NotFoundException] should be thrownBy await(result)

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/stubs/ACAStubs.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/stubs/ACAStubs.scala
@@ -1,7 +1,6 @@
 package uk.gov.hmrc.agentinvitationsfrontend.stubs
 
 import com.github.tomakehurst.wiremock.client.WireMock.{put, _}
-import org.joda.time.LocalDate
 import uk.gov.hmrc.agentinvitationsfrontend.UriPathEncoding._
 import uk.gov.hmrc.agentinvitationsfrontend.support.WireMockSupport
 import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, InvitationId}
@@ -81,7 +80,6 @@ trait ACAStubs {
           .withBody(
             s"""
                |{
-               |  "id" : "${invitationId.value}",
                |  "arn" : "${arn.value}",
                |  "service" : "$service",
                |  "clientId" : "$clientId",
@@ -97,17 +95,16 @@ trait ACAStubs {
                |}""".stripMargin)))
   }
 
-  def getExpiredInvitationStub(arn: Arn, clientId: String, invitationId: InvitationId): Unit = {
-    stubFor(get(urlEqualTo(s"/agent-client-authorisation/clients/MTDITID/${encodePathSegment(clientId)}/invitations/received/${invitationId.value}"))
+  def getExpiredInvitationStub(arn: Arn, clientId: String, invitationId: InvitationId, service: String, serviceIdentifier: String): Unit = {
+    stubFor(get(urlEqualTo(s"/agent-client-authorisation/clients/$serviceIdentifier/${encodePathSegment(clientId)}/invitations/received/${invitationId.value}"))
       .willReturn(
         aResponse()
           .withStatus(200)
           .withBody(
             s"""
                |{
-               |  "id" : "${invitationId.value}",
                |  "arn" : "${arn.value}",
-               |  "service" : "HMRC-MTD-IT",
+               |  "service" : "$service",
                |  "clientId" : "${clientId}",
                |  "status" : "Expired",
                |  "created" : "2017-7-31T23:22:50.971Z",
@@ -129,7 +126,6 @@ trait ACAStubs {
           .withBody(
             s"""
                |{
-               |  "id" : "${invitationId.value}",
                |  "arn" : "${arn.value}",
                |  "service" : "$service",
                |  "clientId" : "${clientId}",

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/stubs/ACAStubs.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/stubs/ACAStubs.scala
@@ -1,6 +1,7 @@
 package uk.gov.hmrc.agentinvitationsfrontend.stubs
 
 import com.github.tomakehurst.wiremock.client.WireMock.{put, _}
+import org.joda.time.LocalDate
 import uk.gov.hmrc.agentinvitationsfrontend.UriPathEncoding._
 import uk.gov.hmrc.agentinvitationsfrontend.support.WireMockSupport
 import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, InvitationId}
@@ -24,7 +25,7 @@ trait ACAStubs {
           .withHeader("location", s"$wireMockBaseUrlAsString/agent-client-authorisation/clients/$serviceIdentifier/${encodePathSegment(clientId)}/invitations/received/${invitationId.value}")))
   }
 
-  def createInvitationStubForPIR(arn: Arn, clientId: String, invitationId: InvitationId, suppliedClientId: String, postcode: String, service: String, serviceIdentifier: String): Unit = {
+  def createInvitationStubForPIR(arn: Arn, clientId: String, invitationId: InvitationId, suppliedClientId: String, service: String, serviceIdentifier: String): Unit = {
     stubFor(post(urlEqualTo(s"/agent-client-authorisation/agencies/${encodePathSegment(arn.value)}/invitations/sent")).withRequestBody(
       equalToJson(s"""
                      |{
@@ -80,12 +81,14 @@ trait ACAStubs {
           .withBody(
             s"""
                |{
+               |  "id" : "${invitationId.value}",
                |  "arn" : "${arn.value}",
                |  "service" : "$service",
                |  "clientId" : "$clientId",
                |  "status" : "$status",
                |  "created" : "2017-10-31T23:22:50.971Z",
                |  "lastUpdated" : "2017-10-31T23:22:50.971Z",
+               |  "expiryDate" : "2017-12-18",
                |  "_links": {
                |    	"self" : {
                |			  "href" : "$wireMockBaseUrlAsString/agent-client-authorisation/agencies/${arn.value}/invitations/sent/${invitationId.value}"
@@ -102,12 +105,14 @@ trait ACAStubs {
           .withBody(
             s"""
                |{
+               |  "id" : "${invitationId.value}",
                |  "arn" : "${arn.value}",
                |  "service" : "HMRC-MTD-IT",
                |  "clientId" : "${clientId}",
                |  "status" : "Expired",
                |  "created" : "2017-7-31T23:22:50.971Z",
                |  "lastUpdated" : "2017-10-31T23:22:50.971Z",
+               |  "expiryDate" : "2017-12-18",
                |  "_links": {
                |    	"self" : {
                |			  "href" : "$wireMockBaseUrlAsString/agent-client-authorisation/agencies/${arn.value}/invitations/sent/${invitationId.value}"
@@ -124,12 +129,14 @@ trait ACAStubs {
           .withBody(
             s"""
                |{
+               |  "id" : "${invitationId.value}",
                |  "arn" : "${arn.value}",
                |  "service" : "$service",
                |  "clientId" : "${clientId}",
                |  "status" : "Accepted",
                |  "created" : "2017-10-31T23:22:50.971Z",
                |  "lastUpdated" : "2017-10-31T23:22:50.971Z",
+               |  "expiryDate" : "2017-12-18",
                |  "_links": {
                |    	"self" : {
                |			  "href" : "$wireMockBaseUrlAsString/agent-client-authorisation/agencies/${arn.value}/invitations/sent/${invitationId.value}"
@@ -177,9 +184,9 @@ trait ACAStubs {
   }
 
   def alreadyActionedAcceptInvitationStub(clientId: String, invitationId: InvitationId, serviceIdentifier: String): Unit = {
-    val mtdItIdEncoded = encodePathSegment(clientId)
+    val identifierEncoded = encodePathSegment(clientId)
     val invitationIdEncoded = encodePathSegment(invitationId.value)
-    stubFor(put(urlEqualTo(s"/agent-client-authorisation/clients/$serviceIdentifier/$mtdItIdEncoded/invitations/received/$invitationIdEncoded/accept"))
+    stubFor(put(urlEqualTo(s"/agent-client-authorisation/clients/$serviceIdentifier/$identifierEncoded/invitations/received/$invitationIdEncoded/accept"))
       .willReturn(
         aResponse()
           .withStatus(403).withBody(
@@ -193,9 +200,9 @@ trait ACAStubs {
   }
 
   def acceptInvitationNoPermissionStub(clientId: String, invitationId: InvitationId, serviceIdentifier: String): Unit = {
-    val mtdItIdEncoded = encodePathSegment(clientId)
+    val identifierEncoded = encodePathSegment(clientId)
     val invitationIdEncoded = encodePathSegment(invitationId.value)
-    stubFor(put(urlEqualTo(s"/agent-client-authorisation/clients/$serviceIdentifier/$mtdItIdEncoded/invitations/received/$invitationIdEncoded/accept"))
+    stubFor(put(urlEqualTo(s"/agent-client-authorisation/clients/$serviceIdentifier/$identifierEncoded/invitations/received/$invitationIdEncoded/accept"))
       .willReturn(
         aResponse()
           .withStatus(403).withBody(
@@ -209,9 +216,9 @@ trait ACAStubs {
   }
 
   def verifyAcceptInvitationAttempt(clientId: String, invitationId: InvitationId, serviceIdentifier: String): Unit = {
-    val mtdItIdEncoded = encodePathSegment(clientId)
+    val identifierEncoded = encodePathSegment(clientId)
     val invitationIdEncoded = encodePathSegment(invitationId.value)
-    verify(1, putRequestedFor(urlEqualTo(s"/agent-client-authorisation/clients/$serviceIdentifier/$mtdItIdEncoded/invitations/received/$invitationIdEncoded/accept")))
+    verify(1, putRequestedFor(urlEqualTo(s"/agent-client-authorisation/clients/$serviceIdentifier/$identifierEncoded/invitations/received/$invitationIdEncoded/accept")))
   }
 
   def rejectInvitationStub(clientId: String, invitationId: InvitationId, serviceIdentifier: String): Unit = {
@@ -223,18 +230,18 @@ trait ACAStubs {
   }
 
   private def rejectInvitationStub(clientId: String, invitationId: InvitationId, responseStatus: Int, serviceIdentifier: String): Unit = {
-    val mtdItIdEncoded = encodePathSegment(clientId)
+    val identifierEncoded = encodePathSegment(clientId)
     val invitationIdEncoded = encodePathSegment(invitationId.value)
-    stubFor(put(urlEqualTo(s"/agent-client-authorisation/clients/$serviceIdentifier/$mtdItIdEncoded/invitations/received/$invitationIdEncoded/reject"))
+    stubFor(put(urlEqualTo(s"/agent-client-authorisation/clients/$serviceIdentifier/$identifierEncoded/invitations/received/$invitationIdEncoded/reject"))
       .willReturn(
         aResponse()
           .withStatus(responseStatus)))
   }
 
   def alreadyActionedRejectInvitationStub(clientId: String, invitationId: InvitationId, serviceIdentifier: String): Unit = {
-    val mtdItIdEncoded = encodePathSegment(clientId)
+    val identifierEncoded = encodePathSegment(clientId)
     val invitationIdEncoded = encodePathSegment(invitationId.value)
-    stubFor(put(urlEqualTo(s"/agent-client-authorisation/clients/$serviceIdentifier/$mtdItIdEncoded/invitations/received/$invitationIdEncoded/reject"))
+    stubFor(put(urlEqualTo(s"/agent-client-authorisation/clients/$serviceIdentifier/$identifierEncoded/invitations/received/$invitationIdEncoded/reject"))
       .willReturn(
         aResponse()
           .withStatus(403).withBody(
@@ -248,8 +255,8 @@ trait ACAStubs {
   }
 
   def verifyRejectInvitationAttempt(clientId: String, invitationId: InvitationId, serviceIdentifier: String): Unit = {
-    val mtdItIdEncoded = encodePathSegment(clientId)
+    val identifierEncoded = encodePathSegment(clientId)
     val invitationIdEncoded = encodePathSegment(invitationId.value)
-    verify(1, putRequestedFor(urlEqualTo(s"/agent-client-authorisation/clients/$serviceIdentifier/$mtdItIdEncoded/invitations/received/$invitationIdEncoded/reject")))
+    verify(1, putRequestedFor(urlEqualTo(s"/agent-client-authorisation/clients/$serviceIdentifier/$identifierEncoded/invitations/received/$invitationIdEncoded/reject")))
   }
 }

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/support/BaseISpec.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/support/BaseISpec.scala
@@ -52,6 +52,8 @@ abstract class BaseISpec extends UnitSpec with OneAppPerSuite with WireMockSuppo
 
   protected def htmlEscapedMessage(key: String, args: Any*): String = HtmlFormat.escape(Messages(key, args: _*)).toString
 
+  protected def hasMessage(key: String, args: Any*): String = Messages(key, args: _*).toString
+
   implicit def hc(implicit request: FakeRequest[_]): HeaderCarrier = HeaderCarrierConverter.fromHeadersAndSession(request.headers, Some(request.session))
 
 }


### PR DESCRIPTION
Copy Change and Add deadline date on the create invitation complete page. Refactor Invitations Model to match backend service. Plus Updated Tests.