### PR TITLE
[LS] Fix back link to correct routing

### DIFF
--- a/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/confirm_terms.scala.html
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/confirm_terms.scala.html
@@ -91,6 +91,6 @@
 
     <br />
 
-    <a href="#" class="back-link" id="back">@Messages("confirm-terms.back")</a>
+    <a href="@routes.ClientsInvitationController.getConfirmInvitation(invitationId)" class="back-link" id="back">@Messages("confirm-terms.back")</a>
 
 }


### PR DESCRIPTION
A back link has been added to the confirm terms page. Currently it doesn't do anything.
the options were: 1. Remove the back link or 2. Fix the routing on the back link.
This Commit implements option 2.2