### PR TITLE
Revert "[APB-2701][PT]: Preserve Cache at NotMatched"

### DIFF
--- a/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentInvitationsITSAControllerJourneyISpec.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentInvitationsITSAControllerJourneyISpec.scala
@@ -224,7 +224,7 @@ class AgentInvitationsITSAControllerJourneyISpec extends BaseISpec with AuthBeha
         checkHtmlResultWithBodyText(result, htmlEscapedMessage("not-matched.itsa.button"))
         checkHasAgentSignOutLink(result)
         verifyAuthoriseAttempt()
-        await(testFastTrackCache.fetch()).get shouldBe invitation
+        await(testFastTrackCache.fetch()).get shouldBe CurrentInvitationInput(serviceITSA)
       }
     }
 


### PR DESCRIPTION
Reverts hmrc/agent-invitations-frontend#242