### PR TITLE
[APB-3386][MP, AO] make clientType a proper type and refactor forms and cache to use it

### DIFF
--- a/app/uk/gov/hmrc/agentinvitationsfrontend/audit/AuditService.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/audit/AuditService.scala
@@ -55,7 +55,7 @@ class AuditService @Inject()(val auditConnector: AuditConnector) {
         "factCheck"            -> result,
         "invitationId"         -> invitationId,
         "agentReferenceNumber" -> arn.value,
-        "clientType"           -> invitation.clientType.getOrElse(""),
+        "clientType"           -> invitation.clientType.map(_.toString).getOrElse(""),
         "clientIdType"         -> invitation.clientIdentifierType,
         "clientId"             -> invitation.clientId,
         "service"              -> invitation.service,

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentLedDeAuthController.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentLedDeAuthController.scala
@@ -233,9 +233,9 @@ class AgentLedDeAuthController @Inject()(
         case _                                                      =>
           //TODO: Fix this loose check
           agentSession.clientType match {
-            case Some("personal") => Redirect(routes.AgentLedDeAuthController.showConfirmCancel())
-            case Some("business") => Redirect(confirmClientCall)
-            case _                => Redirect(clientTypeCall)
+            case Some(ClientType.personal) => Redirect(routes.AgentLedDeAuthController.showConfirmCancel())
+            case Some(ClientType.business) => Redirect(confirmClientCall)
+            case _                         => Redirect(clientTypeCall)
           }
       }
     }
@@ -248,7 +248,7 @@ class AgentLedDeAuthController @Inject()(
 
   override def clientTypeCall: Call = agentsLedDeAuthRootUrl
 
-  override def clientTypePage(form: Form[String], backLinkUrl: String)(
+  override def clientTypePage(form: Form[ClientType], backLinkUrl: String)(
     implicit request: Request[_]): HtmlFormat.Appendable =
     cancelAuthorisation.client_type(form, ClientTypePageConfig(None))
 

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentsFastTrackInvitationController.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentsFastTrackInvitationController.scala
@@ -242,9 +242,11 @@ object AgentsFastTrackInvitationController {
   val validateFastTrackForm: Constraint[AgentFastTrackRequest] =
     Constraint[AgentFastTrackRequest] { formData: AgentFastTrackRequest =>
       formData match {
-        case AgentFastTrackRequest(Some("personal") | None, HMRCMTDIT, "ni", clientId, _) if Nino.isValid(clientId) =>
+        case AgentFastTrackRequest(Some(ClientType.personal) | None, HMRCMTDIT, "ni", clientId, _)
+            if Nino.isValid(clientId) =>
           Valid
-        case AgentFastTrackRequest(Some("personal") | None, HMRCPIR, "ni", clientId, _) if Nino.isValid(clientId) =>
+        case AgentFastTrackRequest(Some(ClientType.personal) | None, HMRCPIR, "ni", clientId, _)
+            if Nino.isValid(clientId) =>
           Valid
         case AgentFastTrackRequest(_, HMRCMTDVAT, "vrn", clientId, _) if Vrn.isValid(clientId) => Valid
         case _                                                                                 => Invalid(ValidationError("INVALID_SUBMISSION"))
@@ -255,7 +257,9 @@ object AgentsFastTrackInvitationController {
     Form(
       mapping(
         "clientType" -> optional(
-          lowerCaseText.verifying("UNSUPPORTED_CLIENT_TYPE", Set("personal", "business").contains _)),
+          lowerCaseText
+            .verifying("UNSUPPORTED_CLIENT_TYPE", Set("personal", "business").contains _)
+            .transform(ClientType.toEnum, ClientType.fromEnum)),
         "service" -> text.verifying("UNSUPPORTED_SERVICE", service => supportedServices.contains(service)),
         "clientIdentifierType" -> text
           .verifying("UNSUPPORTED_CLIENT_ID_TYPE", clientType => supportedTypes.contains(clientType)),
@@ -273,10 +277,10 @@ object AgentsFastTrackInvitationController {
             request.knownFact))
       }).verifying(validateFastTrackForm))
 
-  def clientTypeFor(clientType: Option[String], service: String): Option[String] =
+  def clientTypeFor(clientType: Option[ClientType], service: String): Option[ClientType] =
     clientType.orElse(service match {
-      case "HMRC-MTD-IT"            => Some("personal")
-      case "PERSONAL-INCOME-RECORD" => Some("personal")
+      case "HMRC-MTD-IT"            => Some(ClientType.personal)
+      case "PERSONAL-INCOME-RECORD" => Some(ClientType.personal)
       case _                        => None
     })
 

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/BaseInvitationController.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/BaseInvitationController.scala
@@ -136,9 +136,9 @@ abstract class BaseInvitationController(
     agentSessionCache.fetch.flatMap {
       case Some(cache) =>
         cache.clientType match {
-          case Some("personal") =>
+          case Some(ClientType.personal) =>
             Ok(selectServicePage(form, enabledPersonalServices(isWhitelisted), basketFlag = cache.requests.nonEmpty))
-          case Some("business") =>
+          case Some(ClientType.business) =>
             Ok(businessSelectServicePage(businessForm, basketFlag = cache.requests.nonEmpty, clientTypeCall.url))
           case _ => Redirect(clientTypeCall)
         }
@@ -151,9 +151,9 @@ abstract class BaseInvitationController(
     request: Request[_]): Future[Result] =
     agentSessionCache.fetch.flatMap { car =>
       car.flatMap(_.clientType) match {
-        case Some("personal") => handleSubmitSelectServicePersonal(businessForm)
-        case Some("business") => handleSubmitSelectServiceBusiness(businessForm)
-        case _                => Redirect(clientTypeCall)
+        case Some(ClientType.personal) => handleSubmitSelectServicePersonal(businessForm)
+        case Some(ClientType.business) => handleSubmitSelectServiceBusiness(businessForm)
+        case _                         => Redirect(clientTypeCall)
       }
     }
 
@@ -169,7 +169,7 @@ abstract class BaseInvitationController(
               agentSession match {
                 case Some(cache) =>
                   agentSessionCache
-                    .save(cache.copy(clientType = Some("personal"), service = Some(serviceInput)))
+                    .save(cache.copy(clientType = Some(ClientType.personal), service = Some(serviceInput)))
                     .flatMap(_ =>
                       ifShouldShowService(serviceInput, featureFlags, isWhitelisted) {
                         if (isSupportedWhitelistedService(serviceInput, isWhitelisted)) Redirect(identifyClientCall)
@@ -180,8 +180,8 @@ abstract class BaseInvitationController(
 
             agentSessionCache.fetch.flatMap { cache =>
               cache.flatMap(_.clientType) match {
-                case Some("personal") => updateSessionAndRedirect(cache)
-                case Some("business") =>
+                case Some(ClientType.personal) => updateSessionAndRedirect(cache)
+                case Some(ClientType.business) =>
                   if (serviceInput == HMRCMTDVAT) {
                     updateSessionAndRedirect(cache)
                   } else {
@@ -206,7 +206,7 @@ abstract class BaseInvitationController(
               agentSessionCache.fetch.flatMap {
                 case Some(cache) =>
                   agentSessionCache
-                    .save(cache.copy(clientType = Some("business"), service = Some(HMRCMTDVAT)))
+                    .save(cache.copy(clientType = Some(ClientType.business), service = Some(HMRCMTDVAT)))
                     .flatMap(_ =>
                       ifShouldShowService(HMRCMTDVAT, featureFlags, isWhitelisted) {
                         if (isSupportedWhitelistedService(HMRCMTDVAT, isWhitelisted)) Redirect(identifyClientCall)
@@ -620,10 +620,10 @@ abstract class BaseInvitationController(
                   }
                   .flatMap { _ =>
                     clientType match {
-                      case Some("personal") =>
+                      case Some(ClientType.personal) =>
                         toFuture(Redirect(routes.AgentsInvitationController.showReviewAuthorisations()))
-                      case Some("business") => body
-                      case _                => toFuture(Redirect(clientTypeCall))
+                      case Some(ClientType.business) => body
+                      case _                         => toFuture(Redirect(clientTypeCall))
                     }
                   }
             }
@@ -690,7 +690,7 @@ abstract class BaseInvitationController(
 
   def clientTypeCall: Call = routes.AgentsInvitationController.showClientType()
 
-  def clientTypePage(form: Form[String] = ClientTypeForm.form, backLinkUrl: String = agentServicesAccountUrl)(
+  def clientTypePage(form: Form[ClientType] = ClientTypeForm.form, backLinkUrl: String = agentServicesAccountUrl)(
     implicit request: Request[_]): Appendable =
     client_type(form, ClientTypePageConfig(Some(backLinkUrl)))
 

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/testing/TestEndpointsController.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/testing/TestEndpointsController.scala
@@ -25,7 +25,7 @@ import play.api.{Configuration, Environment, Mode}
 import uk.gov.hmrc.agentinvitationsfrontend.config.ExternalUrls
 import uk.gov.hmrc.agentinvitationsfrontend.connectors.PirRelationshipConnector
 import uk.gov.hmrc.agentinvitationsfrontend.controllers.{AuthActions, CancelAuthorisationForm, CancelRequestForm, DateFieldHelper, PasscodeVerification, TrackResendForm, routes => agentRoutes}
-import uk.gov.hmrc.agentinvitationsfrontend.models.AgentFastTrackRequest
+import uk.gov.hmrc.agentinvitationsfrontend.models.{AgentFastTrackRequest, ClientType}
 import uk.gov.hmrc.agentinvitationsfrontend.models.Services.{supportedClientTypes, supportedServices}
 import uk.gov.hmrc.agentinvitationsfrontend.services.AgentSessionCache
 import uk.gov.hmrc.agentinvitationsfrontend.validators.Validators._
@@ -120,7 +120,7 @@ object TestEndpointsController {
   val testCurrentAuthorisationRequestForm: Form[AgentFastTrackRequest] = {
     Form(
       mapping(
-        "clientType"           -> optional(text),
+        "clientType"           -> optional(text.transform(ClientType.toEnum, ClientType.fromEnum)),
         "service"              -> text,
         "clientIdentifierType" -> text,
         "clientIdentifier"     -> normalizedText,
@@ -142,8 +142,10 @@ object TestEndpointsController {
     Form(
       mapping(
         "service" -> text.verifying("Unsupported Service", service => supportedServices.contains(service)),
-        "clientType" -> optional(text)
-          .verifying("Unsupported client type", clientType => supportedClientTypes.contains(clientType)),
+        "clientType" -> optional(
+          text
+            .verifying("Unsupported client type", clientType => supportedClientTypes.contains(clientType))
+            .transform(ClientType.toEnum, ClientType.fromEnum)),
         "expiryDate" -> text.verifying("Invalid date format", expiryDate => DateFieldHelper.parseDate(expiryDate))
       )(TrackResendForm.apply)(TrackResendForm.unapply))
   }

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/forms/ClientTypeForm.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/forms/ClientTypeForm.scala
@@ -18,12 +18,13 @@ package uk.gov.hmrc.agentinvitationsfrontend.forms
 
 import play.api.data.Forms._
 import play.api.data._
+import uk.gov.hmrc.agentinvitationsfrontend.models.ClientType
 import uk.gov.hmrc.agentinvitationsfrontend.validators.Validators.lowerCaseText
 
 object ClientTypeForm {
   val form = Form(
     single(
       "clientType" -> lowerCaseText.verifying("client.type.invalid", Set("personal", "business").contains _)
-    )
+    ).transform(ClientType.toEnum, ClientType.fromEnum)
   )
 }

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/models/AgentFastTrackRequest.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/models/AgentFastTrackRequest.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.agentinvitationsfrontend.models
 
 case class AgentFastTrackRequest(
-  clientType: Option[String],
+  clientType: Option[ClientType],
   service: String,
   clientIdentifierType: String,
   clientIdentifier: String,
@@ -25,6 +25,6 @@ case class AgentFastTrackRequest(
 
 object AgentFastTrackRequest {
 
-  def apply(clientType: Option[String], service: String): AgentFastTrackRequest =
+  def apply(clientType: Option[ClientType], service: String): AgentFastTrackRequest =
     AgentFastTrackRequest(clientType, service, "", "", None)
 }

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/models/AgentInvitation.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/models/AgentInvitation.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.agentinvitationsfrontend.models
 
 import play.api.libs.json.Json
 
-case class AgentInvitation(clientType: Option[String], service: String, clientIdType: String, clientId: String)
+case class AgentInvitation(clientType: Option[ClientType], service: String, clientIdType: String, clientId: String)
 
 object AgentInvitation {
   implicit val format = Json.format[AgentInvitation]

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/models/AgentSession.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/models/AgentSession.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.agentinvitationsfrontend.models
 import play.api.libs.json.{Format, Json}
 
 case class AgentSession(
-  clientType: Option[String] = None,
+  clientType: Option[ClientType] = None,
   service: Option[String] = None,
   clientIdentifierType: Option[String] = None,
   clientIdentifier: Option[String] = None,
@@ -29,7 +29,7 @@ case class AgentSession(
   fromFastTrack: Boolean = false,
   isDeAuthJourney: Boolean = false,
   requests: Set[AuthorisationRequest] = Set.empty,
-  clientTypeForInvitationSent: Option[String] = None)
+  clientTypeForInvitationSent: Option[ClientType] = None)
 
 object AgentSession {
   implicit val format: Format[AgentSession] = Json.format[AgentSession]

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/models/ClientType.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/models/ClientType.scala
@@ -15,9 +15,27 @@
  */
 
 package uk.gov.hmrc.agentinvitationsfrontend.models
+import play.api.libs.json.Format
 
 sealed trait ClientType
 
-case object Personal extends ClientType
+object ClientType {
 
-case object Business extends ClientType
+  case object personal extends ClientType
+  case object business extends ClientType
+
+  def toEnum: String => ClientType = {
+    case "personal" => personal
+    case "business" => business
+    case alien      => throw new Exception(s"Client type $alien not supported")
+  }
+
+  def fromEnum: ClientType => String = {
+    case ClientType.personal => "personal"
+    case ClientType.business => "business"
+  }
+
+  implicit val formats: Format[ClientType] = new EnumFormats[ClientType] {
+    override val deserialize: String => ClientType = toEnum
+  }.formats
+}

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/models/EnumFormats.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/models/EnumFormats.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentinvitationsfrontend.models
+import play.api.libs.json._
+
+trait EnumFormats[E] {
+
+  val deserialize: String => E
+
+  final val reads: Reads[E] = new Reads[E] {
+    override def reads(json: JsValue): JsResult[E] = json match {
+      case JsString(name) => JsSuccess(deserialize(name))
+      case o              => JsError(s"Cannot parse Enum from $o, must be JsString.")
+    }
+  }
+
+  final val writes: Writes[E] = new Writes[E] {
+    override def writes(enum: E): JsValue = JsString(nameOf(enum))
+  }
+
+  final def formats: Format[E] = Format(reads, writes)
+
+  final def nameOf(enum: E): String = {
+    val className = enum.getClass.getName
+    val lastDot = className.lastIndexOf('.')
+    val typeName = {
+      val s = if (lastDot < 0) className else className.substring(lastDot + 1)
+      if (s.last == '$') s.init else s
+    }
+    val lastDollar = typeName.lastIndexOf('$')
+    if (lastDollar < 0) typeName else typeName.substring(lastDollar + 1)
+  }
+
+}

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/models/Invitation.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/models/Invitation.scala
@@ -43,7 +43,7 @@ object DOB {
 }
 
 sealed trait Invitation {
-  val clientType: Option[String]
+  val clientType: Option[ClientType]
 
   val service: String
 
@@ -58,7 +58,7 @@ sealed trait Invitation {
 
 object Invitation {
   def apply(
-    clientType: Option[String],
+    clientType: Option[ClientType],
     service: String,
     clientIdentifier: String,
     knownFact: Option[String]): Invitation =
@@ -108,7 +108,7 @@ object Invitation {
 case class ItsaInvitation(
   clientIdentifier: Nino,
   postcode: Option[Postcode],
-  clientType: Option[String] = Services.personal,
+  clientType: Option[ClientType] = Some(ClientType.personal),
   service: String = Services.HMRCMTDIT,
   clientIdentifierType: String = "ni")
     extends Invitation {
@@ -122,7 +122,7 @@ object ItsaInvitation {
 case class PirInvitation(
   clientIdentifier: Nino,
   dob: Option[DOB],
-  clientType: Option[String] = Services.personal,
+  clientType: Option[ClientType] = Some(ClientType.personal),
   service: String = Services.HMRCPIR,
   clientIdentifierType: String = "ni")
     extends Invitation {
@@ -134,7 +134,7 @@ object PirInvitation {
 }
 
 case class VatInvitation(
-  clientType: Option[String],
+  clientType: Option[ClientType],
   clientIdentifier: Vrn,
   vatRegDate: Option[VatRegDate],
   service: String = Services.HMRCMTDVAT,

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/models/Services.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/models/Services.scala
@@ -49,10 +49,7 @@ object Services {
   val supportedServices = List(HMRCMTDIT, HMRCPIR, HMRCMTDVAT)
   val supportedTypes = List("ni", "vrn", "utr")
 
-  //Todo Client Types to be used later
-  val personal = Some("personal")
-  val business = Some("business")
-  val supportedClientTypes = List(personal, business)
+  val supportedClientTypes = List("personal", "business")
 
   def determineService(invitationId: InvitationId): Service =
     invitationId.value.head match {

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/views/agents/cancelAuthorisation/client_type.scala.html
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/views/agents/cancelAuthorisation/client_type.scala.html
@@ -22,7 +22,8 @@
 @import uk.gov.hmrc.agentinvitationsfrontend.views.html.agents.back_link
 
 @import uk.gov.hmrc.agentinvitationsfrontend.views.agents.ClientTypePageConfig
-@(agentForm: Form[String], config: ClientTypePageConfig)(implicit request: Request[_], messages: Messages, configuration: Configuration, externalUrls: ExternalUrls)
+@import uk.gov.hmrc.agentinvitationsfrontend.models.ClientType
+@(agentForm: Form[ClientType], config: ClientTypePageConfig)(implicit request: Request[_], messages: Messages, configuration: Configuration, externalUrls: ExternalUrls)
 
 @uk.gov.hmrc.agentinvitationsfrontend.views.html.main_template(title = error_prefix(agentForm) + Messages("generic.title", Messages("cancel-authorisation.client-type.header"), Messages("title.suffix.agents")), bodyClasses = None, isAgent = true) {
 

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/views/agents/check_details.scala.html
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/views/agents/check_details.scala.html
@@ -29,7 +29,7 @@
 
 @import uk.gov.hmrc.agentinvitationsfrontend.views.agents.CheckDetailsPageConfig
 
-
+@import uk.gov.hmrc.agentinvitationsfrontend.models.ClientType
 @(confirmForm: Form[ConfirmForm], currentInvitationInput: AgentSession, featureFlags: FeatureFlags, serviceMessageKey: String, pageConfig: CheckDetailsPageConfig)(implicit request: Request[_], messages: Messages, configuration: Configuration, externalUrls: ExternalUrls)
 
 @postcodeRegex = @{"^[A-Z]{1,2}[0-9][0-9A-Z]?\\s?[0-9][A-Z]{2}$|BFPO\\s?[0-9]{1,5}$"}
@@ -69,8 +69,8 @@
             </dt>
             <dd class="cya-answer" id="client-type">
                 @{currentInvitationInput.clientType match {
-                    case Some("personal") => Messages("check-details.client-type.personal")
-                    case Some("business") => Messages("check-details.client-type.business")
+                    case Some(ClientType.personal) => Messages("check-details.client-type.personal")
+                    case Some(ClientType.business) => Messages("check-details.client-type.business")
                     case _ => throw new IllegalArgumentException("client type not found")
                 }}
             </dd>

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/views/agents/client_type.scala.html
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/views/agents/client_type.scala.html
@@ -22,7 +22,8 @@
 
 @import uk.gov.hmrc.agentinvitationsfrontend.views.agents.ClientTypePageConfig
 
-@(agentInvitationsForm: Form[String], config: ClientTypePageConfig)(implicit request: Request[_], messages: Messages, configuration: Configuration, externalUrls: ExternalUrls)
+@import uk.gov.hmrc.agentinvitationsfrontend.models.ClientType
+@(agentInvitationsForm: Form[ClientType], config: ClientTypePageConfig)(implicit request: Request[_], messages: Messages, configuration: Configuration, externalUrls: ExternalUrls)
 
 @agentServicesCall = @{s"${externalUrls.agentServicesAccountUrl}/agent-services-account"}
 

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/connectors/InvitationsConnectorISpec.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/connectors/InvitationsConnectorISpec.scala
@@ -4,9 +4,10 @@ import java.net.URL
 
 import org.joda.time.{DateTime, LocalDate}
 import uk.gov.hmrc.agentinvitationsfrontend.UriPathEncoding._
+import uk.gov.hmrc.agentinvitationsfrontend.models.ClientType.{business, personal}
 import uk.gov.hmrc.agentinvitationsfrontend.models.{AgentInvitation, AgentReferenceRecord, StoredInvitation}
 import uk.gov.hmrc.agentinvitationsfrontend.support.{BaseISpec, TestDataCommonSupport}
-import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, InvitationId}
+import uk.gov.hmrc.agentmtdidentifiers.model.Arn
 import uk.gov.hmrc.http._
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -22,17 +23,17 @@ class InvitationsConnectorISpec extends BaseISpec with TestDataCommonSupport {
 
       "return multi-invitation link for valid data" in {
 
-        givenAgentReference(arn, hash, personal.get)
+        givenAgentReference(arn, hash, personal)
 
         val result = await(connector.createAgentLink(arn, "personal"))
         result.isDefined shouldBe true
         result.get should include(
-          s"invitations/${personal.get}/$hash/99-with-flake"
+          s"invitations/$personal/$hash/99-with-flake"
         )
       }
 
       "return an error if unexpected response when creating multi-invitation link" in {
-        givenAgentReferenceNotFound(arn, personal.get)
+        givenAgentReferenceNotFound(arn, personal)
         intercept[NotFoundException] {
           await(connector.createAgentLink(arn, "personal"))
         }
@@ -52,11 +53,11 @@ class InvitationsConnectorISpec extends BaseISpec with TestDataCommonSupport {
     }
 
     "service is for ITSA" should {
-      val agentInvitationITSA = AgentInvitation(Some("personal"), "HMRC-MTD-IT", "ni", "AB123456B")
+      val agentInvitationITSA = AgentInvitation(Some(personal), "HMRC-MTD-IT", "ni", "AB123456B")
       "return a link of a ITSA created invitation" in {
         givenInvitationCreationSucceeds(
           arn,
-          personal,
+          Some(personal),
           "AB123456B",
           invitationIdITSA,
           "AB123456B",
@@ -78,11 +79,11 @@ class InvitationsConnectorISpec extends BaseISpec with TestDataCommonSupport {
     }
 
     "service is for PIR" should {
-      val agentInvitationPIR = AgentInvitation(Some("personal"), "PERSONAL-INCOME-RECORD", "ni", "AB123456B")
+      val agentInvitationPIR = AgentInvitation(Some(personal), "PERSONAL-INCOME-RECORD", "ni", "AB123456B")
       "return a link of a PIR created invitation" in {
         givenInvitationCreationSucceeds(
           arn,
-          personal,
+          Some(personal),
           "AB123456B",
           invitationIdPIR,
           "AB123456B",
@@ -103,11 +104,11 @@ class InvitationsConnectorISpec extends BaseISpec with TestDataCommonSupport {
     }
 
     "service is for VAT" should {
-      val agentInvitationVAT = AgentInvitation(Some("business"), "HMRC-MTD-VAT", "vrn", validVrn.value)
+      val agentInvitationVAT = AgentInvitation(Some(business), "HMRC-MTD-VAT", "vrn", validVrn.value)
       "return a link of a VAT created invitation" in {
         givenInvitationCreationSucceeds(
           arn,
-          business,
+          Some(business),
           validVrn.value,
           invitationIdVAT,
           validVrn.value,

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentInvitationControllerFastTrackOffISpec.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentInvitationControllerFastTrackOffISpec.scala
@@ -6,6 +6,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.agentinvitationsfrontend.controllers.AgentsFastTrackInvitationController.agentFastTrackForm
 import uk.gov.hmrc.agentinvitationsfrontend.models.AgentFastTrackRequest
+import uk.gov.hmrc.agentinvitationsfrontend.models.ClientType.{business, personal}
 import uk.gov.hmrc.agentinvitationsfrontend.services.AgentSessionCache
 import uk.gov.hmrc.agentinvitationsfrontend.support.BaseISpec
 import uk.gov.hmrc.http.HeaderCarrier
@@ -45,7 +46,8 @@ class AgentInvitationControllerFastTrackOffISpec extends BaseISpec {
       )
       .overrides(new TestGuiceModule)
 
-  lazy val fastTrackController: AgentsFastTrackInvitationController = app.injector.instanceOf[AgentsFastTrackInvitationController]
+  lazy val fastTrackController: AgentsFastTrackInvitationController =
+    app.injector.instanceOf[AgentsFastTrackInvitationController]
 
   implicit val hc: HeaderCarrier = HeaderCarrier(sessionId = Some(SessionId("session12345")))
 
@@ -67,7 +69,7 @@ class AgentInvitationControllerFastTrackOffISpec extends BaseISpec {
 
       "creating an ITSA invitation" in {
         val formData =
-          AgentFastTrackRequest(personal, serviceITSA, "ni", validNino.value, Some(validPostcode))
+          AgentFastTrackRequest(Some(personal), serviceITSA, "ni", validNino.value, Some(validPostcode))
         val fastTrackFormData = agentFastTrackForm.fill(formData)
         val result = fastTrack(
           authorisedAsValidAgent(request, arn.value)
@@ -77,7 +79,7 @@ class AgentInvitationControllerFastTrackOffISpec extends BaseISpec {
       }
 
       "creating an IRV invitation" in {
-        val formData = AgentFastTrackRequest(personal, servicePIR, "ni", validNino.value, None)
+        val formData = AgentFastTrackRequest(Some(personal), servicePIR, "ni", validNino.value, None)
         val fastTrackFormData = agentFastTrackForm.fill(formData)
         val result = fastTrack(
           authorisedAsValidAgent(request, arn.value)
@@ -88,7 +90,7 @@ class AgentInvitationControllerFastTrackOffISpec extends BaseISpec {
 
       "creating an VAT invitation" in {
         val formData =
-          AgentFastTrackRequest(business, serviceVAT, "vrn", validVrn.value, Some(validRegistrationDate))
+          AgentFastTrackRequest(Some(business), serviceVAT, "vrn", validVrn.value, Some(validRegistrationDate))
         val fastTrackFormData = agentFastTrackForm.fill(formData)
         val result = fastTrack(
           authorisedAsValidAgent(request, arn.value)

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentInvitationsControllerContinueUrlISpec.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentInvitationsControllerContinueUrlISpec.scala
@@ -2,7 +2,8 @@ package uk.gov.hmrc.agentinvitationsfrontend.controllers
 
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{redirectLocation, _}
-import uk.gov.hmrc.agentinvitationsfrontend.models.AgentSession
+import uk.gov.hmrc.agentinvitationsfrontend.models.{AgentSession, ClientType}
+import uk.gov.hmrc.agentinvitationsfrontend.models.ClientType.{business, personal}
 import uk.gov.hmrc.agentinvitationsfrontend.support.BaseISpec
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.logging.SessionId
@@ -20,12 +21,21 @@ class AgentInvitationsControllerContinueUrlISpec extends BaseISpec {
     val request = FakeRequest("GET", "/agents/invitation-sent")
     val invitationSent = controller.showInvitationSent()
     "return 200 for authorised Agent with valid postcode and redirected to Confirm Invitation Page (secureFlag = false) for ITSA service" in {
-      givenAgentReference(arn, uid, "personal")
+      givenAgentReference(arn, uid, personal)
       val continueUrl = ContinueUrl("/someITSA/Url")
       testAgentSessionCache.save(
-        AgentSession(personal, Some(serviceITSA), Some("ni"), Some(nino), Some(validPostcode), continueUrl = Some("/someITSA/Url"), clientTypeForInvitationSent = personal))
+        AgentSession(
+          Some(personal),
+          Some(serviceITSA),
+          Some("ni"),
+          Some(nino),
+          Some(validPostcode),
+          continueUrl = Some("/someITSA/Url"),
+          clientTypeForInvitationSent = Some(personal)
+        ))
 
-      val result = invitationSent(authorisedAsValidAgent(request.withSession("clientType" -> personal.get), arn.value))
+      val result = invitationSent(
+        authorisedAsValidAgent(request.withSession("clientType" -> ClientType.fromEnum(personal)), arn.value))
 
       status(result) shouldBe 200
       checkHtmlResultWithBodyText(
@@ -49,16 +59,27 @@ class AgentInvitationsControllerContinueUrlISpec extends BaseISpec {
       checkInviteSentExitSurveyAgentSignOutLink(result)
 
       verifyAuthoriseAttempt()
-      await(testAgentSessionCache.get) shouldBe AgentSession(continueUrl = Some(continueUrl.url), clientTypeForInvitationSent = personal)
+      await(testAgentSessionCache.get) shouldBe AgentSession(
+        continueUrl = Some(continueUrl.url),
+        clientTypeForInvitationSent = Some(personal))
     }
 
     "return 200 for authorised Agent, redirected to Confirm Invitation Page (secureFlag = false) for PIR service" in {
-      givenAgentReference(arn, uid, "personal")
+      givenAgentReference(arn, uid, personal)
       val continueUrl = ContinueUrl("http://localhost:9996/tax-history/select-client")
       testAgentSessionCache.save(
-        AgentSession(personal, Some(serviceITSA), Some("ni"), Some(nino), Some(validPostcode), continueUrl = Some("http://localhost:9996/tax-history/select-client"), clientTypeForInvitationSent = personal))
+        AgentSession(
+          Some(personal),
+          Some(serviceITSA),
+          Some("ni"),
+          Some(nino),
+          Some(validPostcode),
+          continueUrl = Some("http://localhost:9996/tax-history/select-client"),
+          clientTypeForInvitationSent = Some(personal)
+        ))
 
-      val result = invitationSent(authorisedAsValidAgent(request.withSession("clientType" -> personal.get), arn.value))
+      val result = invitationSent(
+        authorisedAsValidAgent(request.withSession("clientType" -> ClientType.fromEnum(personal)), arn.value))
 
       status(result) shouldBe 200
       checkHtmlResultWithBodyText(
@@ -82,15 +103,27 @@ class AgentInvitationsControllerContinueUrlISpec extends BaseISpec {
       checkInviteSentExitSurveyAgentSignOutLink(result)
 
       verifyAuthoriseAttempt()
-      await(testAgentSessionCache.get) shouldBe AgentSession(continueUrl = Some(continueUrl.url), clientTypeForInvitationSent = personal)
+      await(testAgentSessionCache.get) shouldBe AgentSession(
+        continueUrl = Some(continueUrl.url),
+        clientTypeForInvitationSent = Some(personal))
     }
 
     "return 200 for authorised Agent with valid vat-reg-date and redirected to Confirm Invitation Page (secureFlag = false) for VAT service" in {
-      givenAgentReference(arn, uid, "business")
+      givenAgentReference(arn, uid, business)
       val continueUrl = ContinueUrl("/someVat/Url")
-      testAgentSessionCache.save(AgentSession(business, Some(serviceITSA), Some("ni"), Some(nino), Some(validPostcode), continueUrl = Some(continueUrl.url), clientTypeForInvitationSent = business))
+      testAgentSessionCache.save(
+        AgentSession(
+          Some(business),
+          Some(serviceITSA),
+          Some("ni"),
+          Some(nino),
+          Some(validPostcode),
+          continueUrl = Some(continueUrl.url),
+          clientTypeForInvitationSent = Some(business)
+        ))
 
-      val result = invitationSent(authorisedAsValidAgent(request.withSession("clientType" -> business.get), arn.value))
+      val result = invitationSent(
+        authorisedAsValidAgent(request.withSession("clientType" -> ClientType.fromEnum(business)), arn.value))
 
       status(result) shouldBe 200
       checkHtmlResultWithBodyText(
@@ -114,7 +147,9 @@ class AgentInvitationsControllerContinueUrlISpec extends BaseISpec {
       checkInviteSentExitSurveyAgentSignOutLink(result)
 
       verifyAuthoriseAttempt()
-      await(testAgentSessionCache.get) shouldBe AgentSession(continueUrl = Some(continueUrl.url), clientTypeForInvitationSent = business)
+      await(testAgentSessionCache.get) shouldBe AgentSession(
+        continueUrl = Some(continueUrl.url),
+        clientTypeForInvitationSent = Some(business))
     }
 
   }

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentInvitationsControllerShowFlagsOffISpec.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentInvitationsControllerShowFlagsOffISpec.scala
@@ -6,6 +6,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.agentinvitationsfrontend.controllers.AgentsFastTrackInvitationController.agentFastTrackForm
 import uk.gov.hmrc.agentinvitationsfrontend.models.AgentFastTrackRequest
+import uk.gov.hmrc.agentinvitationsfrontend.models.ClientType.{business, personal}
 import uk.gov.hmrc.agentinvitationsfrontend.services.AgentSessionCache
 import uk.gov.hmrc.agentinvitationsfrontend.support.BaseISpec
 import uk.gov.hmrc.http.HeaderCarrier
@@ -45,7 +46,8 @@ class AgentInvitationsControllerShowFlagsOffISpec extends BaseISpec {
       )
       .overrides(new TestGuiceModule)
 
-  lazy val fastTrackController: AgentsFastTrackInvitationController = app.injector.instanceOf[AgentsFastTrackInvitationController]
+  lazy val fastTrackController: AgentsFastTrackInvitationController =
+    app.injector.instanceOf[AgentsFastTrackInvitationController]
 
   implicit val hc: HeaderCarrier = HeaderCarrier(sessionId = Some(SessionId("session12345")))
 
@@ -67,7 +69,7 @@ class AgentInvitationsControllerShowFlagsOffISpec extends BaseISpec {
 
       "creating an ITSA invitation" in {
         val formData =
-          AgentFastTrackRequest(Some("personal"), serviceITSA, "ni", nino, Some(validPostcode))
+          AgentFastTrackRequest(Some(personal), serviceITSA, "ni", nino, Some(validPostcode))
         val fastTrackFormData = agentFastTrackForm.fill(formData)
         val result = fastTrack(
           authorisedAsValidAgent(request, arn.value)
@@ -77,7 +79,7 @@ class AgentInvitationsControllerShowFlagsOffISpec extends BaseISpec {
       }
 
       "creating an IRV invitation" in {
-        val formData = AgentFastTrackRequest(Some("personal"), servicePIR, "ni", nino, Some(validPostcode))
+        val formData = AgentFastTrackRequest(Some(personal), servicePIR, "ni", nino, Some(validPostcode))
         val fastTrackFormData = agentFastTrackForm.fill(formData)
         val result = fastTrack(
           authorisedAsValidAgent(request, arn.value)
@@ -88,7 +90,7 @@ class AgentInvitationsControllerShowFlagsOffISpec extends BaseISpec {
 
       "creating an VAT invitation" in {
         val formData =
-          AgentFastTrackRequest(business, serviceVAT, "vrn", validVrn.value, Some(validRegistrationDate))
+          AgentFastTrackRequest(Some(business), serviceVAT, "vrn", validVrn.value, Some(validRegistrationDate))
         val fastTrackFormData = agentFastTrackForm.fill(formData)
         val result = fastTrack(
           authorisedAsValidAgent(request, arn.value)

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentInvitationsIRVControllerJourneyISpec.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentInvitationsIRVControllerJourneyISpec.scala
@@ -4,6 +4,7 @@ import org.joda.time.LocalDate
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{redirectLocation, _}
 import uk.gov.hmrc.agentinvitationsfrontend.forms.ServiceTypeForm
+import uk.gov.hmrc.agentinvitationsfrontend.models.ClientType.personal
 import uk.gov.hmrc.agentinvitationsfrontend.models._
 import uk.gov.hmrc.agentinvitationsfrontend.support.BaseISpec
 import uk.gov.hmrc.domain.Nino
@@ -23,7 +24,7 @@ class AgentInvitationsIRVControllerJourneyISpec extends BaseISpec with AuthBehav
     val submitService = controller.submitSelectService()
 
     "return 303 for authorised Agent with valid Personal Income Record service, redirect to identify client" in {
-      testAgentSessionCache.save(AgentSession(personal, Some(servicePIR)))
+      testAgentSessionCache.save(AgentSession(Some(personal), Some(servicePIR)))
       val serviceForm = ServiceTypeForm.form.fill(servicePIR)
       val result =
         submitService(authorisedAsValidAgent(request.withFormUrlEncodedBody(serviceForm.data.toSeq: _*), arn.value))
@@ -41,7 +42,7 @@ class AgentInvitationsIRVControllerJourneyISpec extends BaseISpec with AuthBehav
     behave like anAuthorisedAgentEndpoint(request, showIdentifyClientForm)
 
     "return 200 for an Agent with HMRC-AS-AGENT enrolment for IRV service" in {
-      testAgentSessionCache.save(AgentSession(personal, Some(servicePIR)))
+      testAgentSessionCache.save(AgentSession(Some(personal), Some(servicePIR)))
       val result = showIdentifyClientForm(authorisedAsValidAgent(request, arn.value))
       status(result) shouldBe 200
 
@@ -70,26 +71,26 @@ class AgentInvitationsIRVControllerJourneyISpec extends BaseISpec with AuthBehav
       "redirect to review-authorisation when a valid NINO is submitted" in {
         givenInvitationCreationSucceeds(
           arn,
-          personal,
+          Some(personal),
           validNino.value,
           invitationIdPIR,
           validNino.value,
           "ni",
           servicePIR,
           "NI")
-        givenAgentReference(arn, "ABCDEFGH", "personal")
+        givenAgentReference(arn, "ABCDEFGH", personal)
         givenMatchingCitizenRecord(validNino, LocalDate.parse(dateOfBirth))
         givenCitizenDetailsAreKnownFor(validNino.value, "First", "Last")
         givenGetAllPendingInvitationsReturnsEmpty(arn, validNino.value, servicePIR)
 
         testAgentSessionCache.save(
-          AgentSession(personal, Some(servicePIR), Some("ni"), Some(validNino.value), Some(dateOfBirth)))
+          AgentSession(Some(personal), Some(servicePIR), Some("ni"), Some(validNino.value), Some(dateOfBirth)))
         val requestWithForm =
           request.withFormUrlEncodedBody(
             "clientIdentifier" -> validNino.value,
-            "dob.year"   -> "1980",
-            "dob.month"  -> "07",
-            "dob.day"    -> "07"
+            "dob.year"         -> "1980",
+            "dob.month"        -> "07",
+            "dob.day"          -> "07"
           )
         val result = submitIdentifyClient(authorisedAsValidAgent(requestWithForm, arn.value))
 
@@ -128,15 +129,15 @@ class AgentInvitationsIRVControllerJourneyISpec extends BaseISpec with AuthBehav
       "redirect to already-authorisation-pending when a valid NINO is submitted but authorisation already exists" in {
         givenGetAllPendingInvitationsReturnsSome(arn, validNino.value, servicePIR)
         testAgentSessionCache.save(
-          AgentSession(personal, Some(servicePIR), Some("ni"), Some(validNino.value), Some(dateOfBirth)))
+          AgentSession(Some(personal), Some(servicePIR), Some("ni"), Some(validNino.value), Some(dateOfBirth)))
         givenMatchingCitizenRecord(validNino, LocalDate.parse(dateOfBirth))
 
         val requestWithForm =
           request.withFormUrlEncodedBody(
             "clientIdentifier" -> validNino.value,
-            "dob.year"   -> "1980",
-            "dob.month"  -> "07",
-            "dob.day"    -> "07"
+            "dob.year"         -> "1980",
+            "dob.month"        -> "07",
+            "dob.day"          -> "07"
           )
         val result = submitIdentifyClient(authorisedAsValidAgent(requestWithForm, arn.value))
 
@@ -147,15 +148,22 @@ class AgentInvitationsIRVControllerJourneyISpec extends BaseISpec with AuthBehav
       "redirect to already-authorisation-pending when a valid NINO is submitted but it already exists in the basket" in {
         givenGetAllPendingInvitationsReturnsEmpty(arn, validNino.value, servicePIR)
         testAgentSessionCache.save(
-          AgentSession(personal, Some(servicePIR), Some("ni"), Some(validNino.value), Some(dateOfBirth), requests = Set(AuthorisationRequest( "clientName", PirInvitation(validNino, Some(DOB(dateOfBirth)))))))
+          AgentSession(
+            Some(personal),
+            Some(servicePIR),
+            Some("ni"),
+            Some(validNino.value),
+            Some(dateOfBirth),
+            requests = Set(AuthorisationRequest("clientName", PirInvitation(validNino, Some(DOB(dateOfBirth)))))
+          ))
         givenMatchingCitizenRecord(validNino, LocalDate.parse(dateOfBirth))
 
         val requestWithForm =
           request.withFormUrlEncodedBody(
             "clientIdentifier" -> validNino.value,
-            "dob.year"   -> "1980",
-            "dob.month"  -> "07",
-            "dob.day"    -> "07"
+            "dob.year"         -> "1980",
+            "dob.month"        -> "07",
+            "dob.day"          -> "07"
           )
         val result = submitIdentifyClient(authorisedAsValidAgent(requestWithForm, arn.value))
 
@@ -165,7 +173,14 @@ class AgentInvitationsIRVControllerJourneyISpec extends BaseISpec with AuthBehav
 
       "redirect to already-authorisation-present when a valid NINO is submitted but client already has relationship with agent for this service" in {
         testAgentSessionCache.save(
-          AgentSession(personal, Some(servicePIR), Some("ni"), Some(validNino.value), Some(dateOfBirth), requests = Set(AuthorisationRequest( "clientName", PirInvitation(Nino("AB123456B"), Some(DOB(dateOfBirth)))))))
+          AgentSession(
+            Some(personal),
+            Some(servicePIR),
+            Some("ni"),
+            Some(validNino.value),
+            Some(dateOfBirth),
+            requests = Set(AuthorisationRequest("clientName", PirInvitation(Nino("AB123456B"), Some(DOB(dateOfBirth)))))
+          ))
 
         givenMatchingCitizenRecord(validNino, LocalDate.parse(dateOfBirth))
 
@@ -174,9 +189,9 @@ class AgentInvitationsIRVControllerJourneyISpec extends BaseISpec with AuthBehav
         val requestWithForm =
           request.withFormUrlEncodedBody(
             "clientIdentifier" -> validNino.value,
-            "dob.year"   -> "1980",
-            "dob.month"  -> "07",
-            "dob.day"    -> "07"
+            "dob.year"         -> "1980",
+            "dob.month"        -> "07",
+            "dob.day"          -> "07"
           )
         val result = submitIdentifyClient(authorisedAsValidAgent(requestWithForm, arn.value))
 
@@ -185,7 +200,7 @@ class AgentInvitationsIRVControllerJourneyISpec extends BaseISpec with AuthBehav
       }
 
       "redisplay page with errors when an empty NINO is submitted" in {
-        testAgentSessionCache.save(AgentSession(personal, Some(servicePIR)))
+        testAgentSessionCache.save(AgentSession(Some(personal), Some(servicePIR)))
         val requestWithForm = request.withFormUrlEncodedBody("clientIdentifier" -> "")
         val result = submitIdentifyClient(authorisedAsValidAgent(requestWithForm, arn.value))
 
@@ -195,7 +210,7 @@ class AgentInvitationsIRVControllerJourneyISpec extends BaseISpec with AuthBehav
       }
 
       "redisplay page with errors when an invalid NINO is submitted" in {
-        testAgentSessionCache.save(AgentSession(personal, Some(servicePIR)))
+        testAgentSessionCache.save(AgentSession(Some(personal), Some(servicePIR)))
         val requestWithForm = request.withFormUrlEncodedBody("clientIdentifier" -> "invalid")
         val result = submitIdentifyClient(authorisedAsValidAgent(requestWithForm, arn.value))
 
@@ -205,12 +220,12 @@ class AgentInvitationsIRVControllerJourneyISpec extends BaseISpec with AuthBehav
       }
 
       "redisplay page with errors when an no date of birth is submitted" in {
-        testAgentSessionCache.save(AgentSession(personal, Some(servicePIR)))
+        testAgentSessionCache.save(AgentSession(Some(personal), Some(servicePIR)))
         val requestWithForm = request.withFormUrlEncodedBody(
           "clientIdentifier" -> validNino.value,
-          "dob.year"   -> "",
-          "dob.month"  -> "",
-          "dob.day"    -> ""
+          "dob.year"         -> "",
+          "dob.month"        -> "",
+          "dob.day"          -> ""
         )
         val result = submitIdentifyClient(authorisedAsValidAgent(requestWithForm, arn.value))
 
@@ -220,12 +235,12 @@ class AgentInvitationsIRVControllerJourneyISpec extends BaseISpec with AuthBehav
       }
 
       "redisplay page with errors when an invalid date of birth is submitted" in {
-        testAgentSessionCache.save(AgentSession(personal, Some(servicePIR)))
+        testAgentSessionCache.save(AgentSession(Some(personal), Some(servicePIR)))
         val requestWithForm = request.withFormUrlEncodedBody(
           "clientIdentifier" -> validNino.value,
-          "dob.year"   -> "9999",
-          "dob.month"  -> "99",
-          "dob.day"    -> "99"
+          "dob.year"         -> "9999",
+          "dob.month"        -> "99",
+          "dob.day"          -> "99"
         )
         val result = submitIdentifyClient(authorisedAsValidAgent(requestWithForm, arn.value))
 
@@ -235,7 +250,7 @@ class AgentInvitationsIRVControllerJourneyISpec extends BaseISpec with AuthBehav
       }
 
       "redirect to /agents/select-service if service is missing" in {
-        testAgentSessionCache.save(AgentSession(personal))
+        testAgentSessionCache.save(AgentSession(Some(personal)))
         val requestWithForm = request.withFormUrlEncodedBody("clientIdentifier" -> validNino.value)
         val result = submitIdentifyClient(authorisedAsValidAgent(requestWithForm, arn.value))
 
@@ -250,9 +265,15 @@ class AgentInvitationsIRVControllerJourneyISpec extends BaseISpec with AuthBehav
     val invitationSent = controller.showInvitationSent()
 
     "return 200 for authorised Agent successfully created IRV invitation and redirected to Confirm Invitation Page (secureFlag = false) with no continue Url" in {
-      givenAgentReference(arn, uid, "personal")
+      givenAgentReference(arn, uid, personal)
       testAgentSessionCache.save(
-        AgentSession(personal, Some(servicePIR), Some("ni"), Some(validNino.value), Some(dateOfBirth), clientTypeForInvitationSent = personal))
+        AgentSession(
+          Some(personal),
+          Some(servicePIR),
+          Some("ni"),
+          Some(validNino.value),
+          Some(dateOfBirth),
+          clientTypeForInvitationSent = Some(personal)))
 
       val result = invitationSent(authorisedAsValidAgent(request, arn.value))
       status(result) shouldBe 200
@@ -277,7 +298,7 @@ class AgentInvitationsIRVControllerJourneyISpec extends BaseISpec with AuthBehav
       checkInviteSentExitSurveyAgentSignOutLink(result)
 
       //check if we have cleared everything in cache except clientTypeForInvitationsSent
-      await(testAgentSessionCache.get) shouldBe AgentSession(clientTypeForInvitationSent = personal)
+      await(testAgentSessionCache.get) shouldBe AgentSession(clientTypeForInvitationSent = Some(personal))
 
       verifyAuthoriseAttempt()
     }

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentInvitationsITSAControllerJourneyISpec.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentInvitationsITSAControllerJourneyISpec.scala
@@ -5,6 +5,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers.{redirectLocation, _}
 import uk.gov.hmrc.agentinvitationsfrontend.controllers.AgentsInvitationController._
 import uk.gov.hmrc.agentinvitationsfrontend.forms.{ItsaClientForm, ServiceTypeForm}
+import uk.gov.hmrc.agentinvitationsfrontend.models.ClientType.personal
 import uk.gov.hmrc.agentinvitationsfrontend.models._
 import uk.gov.hmrc.agentinvitationsfrontend.support.BaseISpec
 import uk.gov.hmrc.http.HeaderCarrier
@@ -23,7 +24,7 @@ class AgentInvitationsITSAControllerJourneyISpec extends BaseISpec with AuthBeha
     val submitService = controller.submitSelectService()
 
     "return 303 for authorised Agent with valid ITSA service, redirect to enter identify-client page" in {
-      testAgentSessionCache.save(AgentSession(personal, Some(serviceITSA)))
+      testAgentSessionCache.save(AgentSession(Some(personal), Some(serviceITSA)))
       val serviceForm = ServiceTypeForm.form.fill(serviceITSA)
       val result =
         submitService(authorisedAsValidAgent(request.withFormUrlEncodedBody(serviceForm.data.toSeq: _*), arn.value))
@@ -41,7 +42,7 @@ class AgentInvitationsITSAControllerJourneyISpec extends BaseISpec with AuthBeha
     behave like anAuthorisedAgentEndpoint(request, showIdentifyClientForm)
 
     "return 200 for an Agent with HMRC-AS-AGENT enrolment for ITSA service" in {
-      testAgentSessionCache.save(AgentSession(personal, Some(serviceITSA)))
+      testAgentSessionCache.save(AgentSession(Some(personal), Some(serviceITSA)))
       val result = showIdentifyClientForm(authorisedAsValidAgent(request, arn.value))
       status(result) shouldBe 200
 
@@ -75,12 +76,18 @@ class AgentInvitationsITSAControllerJourneyISpec extends BaseISpec with AuthBeha
     "service is HMRC-MTD-IT" should {
 
       "redirect to confirm-client when a valid NINO and postcode are submitted" in {
-        val authRequest= AuthorisationRequest( "clientName", ItsaInvitation(validNino, Some(Postcode(validPostcode))))
+        val authRequest = AuthorisationRequest("clientName", ItsaInvitation(validNino, Some(Postcode(validPostcode))))
         testAgentSessionCache.save(
-          AgentSession(personal, Some(serviceITSA), Some("ni"), Some(validNino.value), Some(validPostcode), requests = Set(authRequest)))
+          AgentSession(
+            Some(personal),
+            Some(serviceITSA),
+            Some("ni"),
+            Some(validNino.value),
+            Some(validPostcode),
+            requests = Set(authRequest)))
         givenInvitationCreationSucceeds(
           arn,
-          personal,
+          Some(personal),
           validNino.value,
           invitationIdITSA,
           validNino.value,
@@ -91,9 +98,8 @@ class AgentInvitationsITSAControllerJourneyISpec extends BaseISpec with AuthBeha
         givenGetAllPendingInvitationsReturnsEmpty(arn, validNino.value, serviceITSA)
         givenAgentReferenceRecordExistsForArn(arn, "uid")
 
-        val requestWithForm = request.withFormUrlEncodedBody(
-          "clientIdentifier" -> validNino.value,
-          "postcode"        -> validPostcode)
+        val requestWithForm =
+          request.withFormUrlEncodedBody("clientIdentifier" -> validNino.value, "postcode" -> validPostcode)
         val result = submitIdentifyClient(authorisedAsValidAgent(requestWithForm, arn.value))
 
         status(result) shouldBe 303
@@ -104,7 +110,7 @@ class AgentInvitationsITSAControllerJourneyISpec extends BaseISpec with AuthBeha
         testAgentSessionCache.save(AgentSession())
         givenInvitationCreationSucceeds(
           arn,
-          personal,
+          Some(personal),
           validNino.value,
           invitationIdITSA,
           validNino.value,
@@ -126,7 +132,7 @@ class AgentInvitationsITSAControllerJourneyISpec extends BaseISpec with AuthBeha
       }
 
       "redisplay page with errors when an empty NINO is submitted" in {
-        testAgentSessionCache.save(AgentSession(personal, Some(serviceITSA)))
+        testAgentSessionCache.save(AgentSession(Some(personal), Some(serviceITSA)))
         val requestWithForm = request
           .withFormUrlEncodedBody("clientIdentifier" -> "", "postcode" -> validPostcode)
         val result = submitIdentifyClient(authorisedAsValidAgent(requestWithForm, arn.value))
@@ -137,10 +143,9 @@ class AgentInvitationsITSAControllerJourneyISpec extends BaseISpec with AuthBeha
       }
 
       "redisplay page with errors when an invalid NINO is submitted" in {
-        testAgentSessionCache.save(AgentSession(personal, Some(serviceITSA)))
-        val requestWithForm = request.withFormUrlEncodedBody(
-          "clientIdentifier" -> "invalid",
-          "postcode"        -> validPostcode)
+        testAgentSessionCache.save(AgentSession(Some(personal), Some(serviceITSA)))
+        val requestWithForm =
+          request.withFormUrlEncodedBody("clientIdentifier" -> "invalid", "postcode" -> validPostcode)
         val result = submitIdentifyClient(authorisedAsValidAgent(requestWithForm, arn.value))
 
         status(result) shouldBe 200
@@ -149,7 +154,7 @@ class AgentInvitationsITSAControllerJourneyISpec extends BaseISpec with AuthBeha
       }
 
       "redisplay page with errors when an empty postcode is submitted" in {
-        testAgentSessionCache.save(AgentSession(personal, Some(serviceITSA)))
+        testAgentSessionCache.save(AgentSession(Some(personal), Some(serviceITSA)))
         val requestWithForm = request
           .withFormUrlEncodedBody("clientIdentifier" -> validNino.value, "postcode" -> "")
         val result = submitIdentifyClient(authorisedAsValidAgent(requestWithForm, arn.value))
@@ -160,10 +165,9 @@ class AgentInvitationsITSAControllerJourneyISpec extends BaseISpec with AuthBeha
       }
 
       "redisplay page with errors when a postcode with invalid format is submitted" in {
-        testAgentSessionCache.save(AgentSession(personal, Some(serviceITSA)))
-        val requestWithForm = request.withFormUrlEncodedBody(
-          "clientIdentifier" -> validNino.value,
-          "postcode"        -> "invalid")
+        testAgentSessionCache.save(AgentSession(Some(personal), Some(serviceITSA)))
+        val requestWithForm =
+          request.withFormUrlEncodedBody("clientIdentifier" -> validNino.value, "postcode" -> "invalid")
         val result = submitIdentifyClient(authorisedAsValidAgent(requestWithForm, arn.value))
 
         status(result) shouldBe 200
@@ -172,10 +176,9 @@ class AgentInvitationsITSAControllerJourneyISpec extends BaseISpec with AuthBeha
       }
 
       "redisplay page with errors when a postcode with invalid characters is submitted" in {
-        testAgentSessionCache.save(AgentSession(personal, Some(serviceITSA)))
-        val requestWithForm = request.withFormUrlEncodedBody(
-          "clientIdentifier" -> validNino.value,
-          "postcode"        -> "invalid%")
+        testAgentSessionCache.save(AgentSession(Some(personal), Some(serviceITSA)))
+        val requestWithForm =
+          request.withFormUrlEncodedBody("clientIdentifier" -> validNino.value, "postcode" -> "invalid%")
         val result = submitIdentifyClient(authorisedAsValidAgent(requestWithForm, arn.value))
 
         status(result) shouldBe 200
@@ -190,9 +193,15 @@ class AgentInvitationsITSAControllerJourneyISpec extends BaseISpec with AuthBeha
     val invitationSent = controller.showInvitationSent()
 
     "return 200 for authorised Agent successfully created ITSA invitation and redirected to Confirm Invitation Page (secureFlag = false) with no continue Url" in {
-      givenAgentReference(arn, uid, "personal")
+      givenAgentReference(arn, uid, personal)
       testAgentSessionCache.save(
-        AgentSession(personal, Some(serviceITSA), Some("ni"), Some(validNino.value), Some(validPostcode), clientTypeForInvitationSent = personal))
+        AgentSession(
+          Some(personal),
+          Some(serviceITSA),
+          Some("ni"),
+          Some(validNino.value),
+          Some(validPostcode),
+          clientTypeForInvitationSent = Some(personal)))
 
       val result = invitationSent(authorisedAsValidAgent(request, arn.value))
       status(result) shouldBe 200
@@ -216,7 +225,7 @@ class AgentInvitationsITSAControllerJourneyISpec extends BaseISpec with AuthBeha
       checkInviteSentExitSurveyAgentSignOutLink(result)
 
       //check if we have cleared everything in cache except clientTypeForInvitationsSent
-      await(testAgentSessionCache.get) shouldBe AgentSession(clientTypeForInvitationSent = personal)
+      await(testAgentSessionCache.get) shouldBe AgentSession(clientTypeForInvitationSent = Some(personal))
 
       verifyAuthoriseAttempt()
     }
@@ -228,7 +237,7 @@ class AgentInvitationsITSAControllerJourneyISpec extends BaseISpec with AuthBeha
     val featureFlags = FeatureFlags()
 
     "return 403 for authorised Agent who submitted known facts of an not enrolled ITSA client when there are no requests in basket" in {
-      testAgentSessionCache.save(AgentSession(personal, Some(serviceITSA)))
+      testAgentSessionCache.save(AgentSession(Some(personal), Some(serviceITSA)))
       val ninoForm = ItsaClientForm.form(featureFlags.showKfcMtdIt).fill(ItsaClient("", None))
       val result =
         notEnrolled(authorisedAsValidAgent(request.withFormUrlEncodedBody(ninoForm.data.toSeq: _*), arn.value))
@@ -243,8 +252,8 @@ class AgentInvitationsITSAControllerJourneyISpec extends BaseISpec with AuthBeha
     }
 
     "return 403 for authorised Agent who submitted known facts of an not enrolled ITSA client when there are requests in basket" in {
-      val authRequest = AuthorisationRequest( "clientName", ItsaInvitation(validNino, Some(Postcode(validPostcode))))
-      testAgentSessionCache.save(AgentSession(personal, Some(serviceITSA), requests = Set(authRequest)))
+      val authRequest = AuthorisationRequest("clientName", ItsaInvitation(validNino, Some(Postcode(validPostcode))))
+      testAgentSessionCache.save(AgentSession(Some(personal), Some(serviceITSA), requests = Set(authRequest)))
       val ninoForm = ItsaClientForm.form(featureFlags.showKfcMtdIt).fill(ItsaClient("", None))
       val result =
         notEnrolled(authorisedAsValidAgent(request.withFormUrlEncodedBody(ninoForm.data.toSeq: _*), arn.value))
@@ -265,7 +274,13 @@ class AgentInvitationsITSAControllerJourneyISpec extends BaseISpec with AuthBeha
 
     "return 200 and show client trading name" in {
       testAgentSessionCache.save(
-        AgentSession(None, Some(serviceITSA), Some("ni"), Some(validNino.value), Some(validPostcode), fromFastTrack = fromManual))
+        AgentSession(
+          None,
+          Some(serviceITSA),
+          Some("ni"),
+          Some(validNino.value),
+          Some(validPostcode),
+          fromFastTrack = fromManual))
       givenTradingName(validNino, "64 Bit")
 
       val result = showConfirmClient(authorisedAsValidAgent(request, arn.value))
@@ -278,7 +293,13 @@ class AgentInvitationsITSAControllerJourneyISpec extends BaseISpec with AuthBeha
 
     "return 200 and show client's name" in {
       testAgentSessionCache.save(
-        AgentSession(None, Some(serviceITSA), Some("ni"), Some(validNino.value), Some(validPostcode), fromFastTrack = fromManual))
+        AgentSession(
+          None,
+          Some(serviceITSA),
+          Some("ni"),
+          Some(validNino.value),
+          Some(validPostcode),
+          fromFastTrack = fromManual))
       givenTradingNameMissing(validNino)
       givenCitizenDetailsAreKnownFor(validNino.value, "Anne Marri", "Son Pear")
 
@@ -292,7 +313,13 @@ class AgentInvitationsITSAControllerJourneyISpec extends BaseISpec with AuthBeha
 
     "return 200 and no client name was found" in {
       testAgentSessionCache.save(
-        AgentSession(None, Some(serviceITSA), Some("ni"), Some(validNino.value), Some(validPostcode), fromFastTrack = fromManual))
+        AgentSession(
+          None,
+          Some(serviceITSA),
+          Some("ni"),
+          Some(validNino.value),
+          Some(validPostcode),
+          fromFastTrack = fromManual))
       givenTradingNameMissing(validNino)
       givenCitizenDetailsReturns404For(validNino.value)
 
@@ -312,10 +339,16 @@ class AgentInvitationsITSAControllerJourneyISpec extends BaseISpec with AuthBeha
 
     "redirect to show-review-authorisations when YES is selected" in {
       testAgentSessionCache.save(
-        AgentSession(personal, Some(serviceITSA), Some("ni"), Some(validNino.value), Some(validPostcode), fromFastTrack = fromManual))
+        AgentSession(
+          Some(personal),
+          Some(serviceITSA),
+          Some("ni"),
+          Some(validNino.value),
+          Some(validPostcode),
+          fromFastTrack = fromManual))
       givenInvitationCreationSucceeds(
         arn,
-        personal,
+        Some(personal),
         mtdItId.value,
         invitationIdITSA,
         validNino.value,
@@ -323,7 +356,7 @@ class AgentInvitationsITSAControllerJourneyISpec extends BaseISpec with AuthBeha
         serviceITSA,
         "NI")
       givenTradingName(validNino, "64 Bit")
-      givenAgentReference(arn, "ABCDEFGH", "personal")
+      givenAgentReference(arn, "ABCDEFGH", personal)
       givenGetAllPendingInvitationsReturnsEmpty(arn, validNino.value, serviceITSA)
       givenCheckRelationshipItsaWithStatus(arn, validNino.value, 404)
 
@@ -336,10 +369,16 @@ class AgentInvitationsITSAControllerJourneyISpec extends BaseISpec with AuthBeha
 
     "redirect to show identify client when NO is selected" in {
       testAgentSessionCache.save(
-        AgentSession(None, Some(serviceITSA), Some("ni"), Some(validNino.value), Some(validPostcode), fromFastTrack = fromManual))
+        AgentSession(
+          None,
+          Some(serviceITSA),
+          Some("ni"),
+          Some(validNino.value),
+          Some(validPostcode),
+          fromFastTrack = fromManual))
       givenInvitationCreationSucceeds(
         arn,
-        personal,
+        Some(personal),
         mtdItId.value,
         invitationIdITSA,
         validNino.value,
@@ -347,7 +386,7 @@ class AgentInvitationsITSAControllerJourneyISpec extends BaseISpec with AuthBeha
         serviceITSA,
         "NI")
       givenTradingName(validNino, "64 Bit")
-      givenAgentReference(arn, "ABCDEFGH", "personal")
+      givenAgentReference(arn, "ABCDEFGH", personal)
       givenGetAllPendingInvitationsReturnsEmpty(arn, validNino.value, serviceITSA)
 
       val choice = agentConfirmationForm("error message").fill(Confirmation(false))
@@ -358,9 +397,16 @@ class AgentInvitationsITSAControllerJourneyISpec extends BaseISpec with AuthBeha
     }
 
     "redirect to already-invitations-pending when YES is selected but there are already invitations for this client" in {
-      val authRequest = AuthorisationRequest( "clientName", ItsaInvitation(validNino, Some(Postcode(validPostcode))))
+      val authRequest = AuthorisationRequest("clientName", ItsaInvitation(validNino, Some(Postcode(validPostcode))))
       testAgentSessionCache.save(
-        AgentSession(None, Some(serviceITSA), Some("ni"), Some(validNino.value), Some(validPostcode), fromFastTrack = fromManual, requests = Set(authRequest)))
+        AgentSession(
+          None,
+          Some(serviceITSA),
+          Some("ni"),
+          Some(validNino.value),
+          Some(validPostcode),
+          fromFastTrack = fromManual,
+          requests = Set(authRequest)))
       givenGetAllPendingInvitationsReturnsSome(arn, validNino.value, serviceITSA)
 
       val choice = agentConfirmationForm("error message").fill(Confirmation(true))
@@ -371,9 +417,16 @@ class AgentInvitationsITSAControllerJourneyISpec extends BaseISpec with AuthBeha
     }
 
     "redirect to already-invitations-pending when YES is selected but there are already invitations in the basket for this client" in {
-      val authRequest = AuthorisationRequest( "clientName", ItsaInvitation(validNino, Some(Postcode(validPostcode))))
+      val authRequest = AuthorisationRequest("clientName", ItsaInvitation(validNino, Some(Postcode(validPostcode))))
       testAgentSessionCache.save(
-        AgentSession(None, Some(serviceITSA), Some("ni"), Some(validNino.value), Some(validPostcode), fromFastTrack = fromManual, requests = Set(authRequest)))
+        AgentSession(
+          None,
+          Some(serviceITSA),
+          Some("ni"),
+          Some(validNino.value),
+          Some(validPostcode),
+          fromFastTrack = fromManual,
+          requests = Set(authRequest)))
       givenGetAllPendingInvitationsReturnsEmpty(arn, validNino.value, serviceITSA)
 
       val choice = agentConfirmationForm("error message").fill(Confirmation(true))
@@ -385,7 +438,13 @@ class AgentInvitationsITSAControllerJourneyISpec extends BaseISpec with AuthBeha
 
     "redirect to already-authorisation-present when YES is selected but there is already an active relationship for this agent and client" in {
       testAgentSessionCache.save(
-        AgentSession(None, Some(serviceITSA), Some("ni"), Some(validNino.value), Some(validPostcode), fromFastTrack = fromManual))
+        AgentSession(
+          None,
+          Some(serviceITSA),
+          Some("ni"),
+          Some(validNino.value),
+          Some(validPostcode),
+          fromFastTrack = fromManual))
 
       givenGetAllPendingInvitationsReturnsEmpty(arn, validNino.value, serviceITSA)
       givenCheckRelationshipItsaWithStatus(arn, validNino.value, 200)
@@ -398,10 +457,16 @@ class AgentInvitationsITSAControllerJourneyISpec extends BaseISpec with AuthBeha
 
     "redirect to select client type when client type in cache is not supported" in {
       testAgentSessionCache.save(
-        AgentSession(None, Some(serviceITSA), Some("ni"), Some(validNino.value), Some(validPostcode), fromFastTrack = fromManual))
+        AgentSession(
+          None,
+          Some(serviceITSA),
+          Some("ni"),
+          Some(validNino.value),
+          Some(validPostcode),
+          fromFastTrack = fromManual))
       givenInvitationCreationSucceeds(
         arn,
-        personal,
+        Some(personal),
         mtdItId.value,
         invitationIdITSA,
         validNino.value,
@@ -409,7 +474,7 @@ class AgentInvitationsITSAControllerJourneyISpec extends BaseISpec with AuthBeha
         serviceITSA,
         "NI")
       givenTradingName(validNino, "64 Bit")
-      givenAgentReference(arn, "ABCDEFGH", "personal")
+      givenAgentReference(arn, "ABCDEFGH", personal)
       givenGetAllPendingInvitationsReturnsEmpty(arn, validNino.value, serviceITSA)
 
       val choice = agentConfirmationForm("error message").fill(Confirmation(true))
@@ -421,7 +486,13 @@ class AgentInvitationsITSAControllerJourneyISpec extends BaseISpec with AuthBeha
 
     "return 200 for not selecting an option" in {
       testAgentSessionCache.save(
-        AgentSession(None, Some(serviceITSA), Some("ni"), Some(validNino.value), Some(validPostcode), fromFastTrack = fromManual))
+        AgentSession(
+          None,
+          Some(serviceITSA),
+          Some("ni"),
+          Some(validNino.value),
+          Some(validPostcode),
+          fromFastTrack = fromManual))
       givenTradingName(validNino, "64 Bit")
       val result = submitConfirmClient(authorisedAsValidAgent(request, arn.value))
       status(result) shouldBe 200
@@ -436,7 +507,7 @@ class AgentInvitationsITSAControllerJourneyISpec extends BaseISpec with AuthBeha
   def behaveLikeMissingCacheScenarios(action: Action[AnyContent], request: FakeRequest[AnyContentAsEmpty.type]) = {
     "return to identify-client no client identifier found in cache" in {
       testAgentSessionCache.save(
-        AgentSession(None, Some(serviceITSA), Some("ni"), None,None, fromFastTrack = fromManual))
+        AgentSession(None, Some(serviceITSA), Some("ni"), None, None, fromFastTrack = fromManual))
       val result = action(authorisedAsValidAgent(request, arn.value))
       status(result) shouldBe 303
       redirectLocation(result).get shouldBe routes.AgentsInvitationController.showIdentifyClient().url

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentMultiInvitationControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentMultiInvitationControllerISpec.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.agentinvitationsfrontend.controllers
 
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import uk.gov.hmrc.agentinvitationsfrontend.models.ClientType.{business, personal}
 import uk.gov.hmrc.agentinvitationsfrontend.models._
 import uk.gov.hmrc.agentinvitationsfrontend.support.BaseISpec
 import uk.gov.hmrc.http.HeaderCarrier
@@ -37,9 +38,9 @@ class AgentMultiInvitationControllerISpec extends BaseISpec with AuthBehaviours 
     val request = FakeRequest("GET", "/agents/select-service")
 
     "show the select personal service page with review authorisations link if there is content in the authorisationRequest cache" in {
-      testAgentSessionCache.save(
-        AgentSession(
-          personal, requests =  Set(AuthorisationRequest("Gareth Gates", ItsaInvitation(validNino, Some(Postcode(validPostcode)))))))
+      testAgentSessionCache.save(AgentSession(
+        Some(personal),
+        requests = Set(AuthorisationRequest("Gareth Gates", ItsaInvitation(validNino, Some(Postcode(validPostcode)))))))
       val result = controller.showSelectService()(authorisedAsValidAgent(request, arn.value))
       status(result) shouldBe 200
       checkHtmlResultWithBodyText(result, "Return to authorisation requests")
@@ -50,8 +51,11 @@ class AgentMultiInvitationControllerISpec extends BaseISpec with AuthBehaviours 
     "show the select business service page with review authorisations link if there is content in the authorisationRequest cache" in {
       testAgentSessionCache.save(
         AgentSession(
-          business,
-          requests = Set(AuthorisationRequest("Gareth Gates", VatInvitation(Some("business"), validVrn, Some(VatRegDate(validRegistrationDate)))))))
+          Some(business),
+          requests = Set(
+            AuthorisationRequest(
+              "Gareth Gates",
+              VatInvitation(Some(business), validVrn, Some(VatRegDate(validRegistrationDate)))))))
       val result = controller.showSelectService()(authorisedAsValidAgent(request, arn.value))
       status(result) shouldBe 200
       checkHasAgentSignOutLink(result)
@@ -60,7 +64,13 @@ class AgentMultiInvitationControllerISpec extends BaseISpec with AuthBehaviours 
 
     "show the business select service page if there is not content in the authorisationCache but is in the fastTrackCache" in {
       testAgentSessionCache.save(
-        AgentSession(business, Some(serviceITSA), Some("ni"), Some(validNino.value), Some(validPostcode), fromFastTrack = fromFastTrack))
+        AgentSession(
+          Some(business),
+          Some(serviceITSA),
+          Some("ni"),
+          Some(validNino.value),
+          Some(validPostcode),
+          fromFastTrack = fromFastTrack))
       val result = controller.showSelectService()(authorisedAsValidAgent(request, arn.value))
       status(result) shouldBe 200
       checkHasAgentSignOutLink(result)
@@ -70,8 +80,11 @@ class AgentMultiInvitationControllerISpec extends BaseISpec with AuthBehaviours 
     "show the select service page if there is an unsupported client type in the authorisationRequest cache" in {
       testAgentSessionCache.save(
         AgentSession(
-          Some("foo"),
-          requests = Set(AuthorisationRequest("Gareth Gates", VatInvitation(Some("business"), validVrn, Some(VatRegDate(validRegistrationDate)))))))
+          None,
+          requests = Set(
+            AuthorisationRequest(
+              "Gareth Gates",
+              VatInvitation(Some(business), validVrn, Some(VatRegDate(validRegistrationDate)))))))
       val result = controller.showSelectService()(authorisedAsValidAgent(request, arn.value))
       status(result) shouldBe 303
       redirectLocation(result) shouldBe Some(routes.AgentsInvitationController.showClientType().url)
@@ -83,10 +96,9 @@ class AgentMultiInvitationControllerISpec extends BaseISpec with AuthBehaviours 
     val request = FakeRequest("GET", "/agents/review-authorisation")
 
     "show the review authorisations page if there is a single item in the authorisationRequest cache" in {
-      testAgentSessionCache.save(
-        AgentSession(
-          personal,
-          requests = Set(AuthorisationRequest("Gareth Gates", ItsaInvitation(validNino, Some(Postcode(validPostcode)))))))
+      testAgentSessionCache.save(AgentSession(
+        Some(personal),
+        requests = Set(AuthorisationRequest("Gareth Gates", ItsaInvitation(validNino, Some(Postcode(validPostcode)))))))
       val result = controller.showReviewAuthorisations()(authorisedAsValidAgent(request, arn.value))
       status(result) shouldBe 200
       checkHtmlResultWithBodyText(
@@ -122,7 +134,7 @@ class AgentMultiInvitationControllerISpec extends BaseISpec with AuthBehaviours 
     }
 
     "redirect to the all authorisation removed page if there are no authorisations in the cache" in {
-      testAgentSessionCache.save(AgentSession(personal))
+      testAgentSessionCache.save(AgentSession(Some(personal)))
 
       val result = controller.showReviewAuthorisations()(authorisedAsValidAgent(request, arn.value))
       status(result) shouldBe 303
@@ -139,7 +151,7 @@ class AgentMultiInvitationControllerISpec extends BaseISpec with AuthBehaviours 
   "POST /agents/review-authorisations" should {
     val request = FakeRequest("POST", "/agents/review-authorisation")
     "Redirect to select service if YES is selected on the review-authorisations page" in new AgentAuthorisationFullCacheScenario {
-      testAgentSessionCache.save(AgentSession(personal, Some(serviceVAT)))
+      testAgentSessionCache.save(AgentSession(Some(personal), Some(serviceVAT)))
       val result = controller.submitReviewAuthorisations()(
         authorisedAsValidAgent(request, arn.value).withFormUrlEncodedBody("accepted" -> "true"))
       status(result) shouldBe 303
@@ -149,7 +161,7 @@ class AgentMultiInvitationControllerISpec extends BaseISpec with AuthBehaviours 
     "Redirect to complete if NO is selected and all invitation creation is successful" in new AgentAuthorisationFullCacheScenario {
       givenInvitationCreationSucceeds(
         arn,
-        personal,
+        Some(personal),
         validNino.value,
         invitationIdITSA,
         validNino.value,
@@ -158,7 +170,7 @@ class AgentMultiInvitationControllerISpec extends BaseISpec with AuthBehaviours 
         "NI")
       givenInvitationCreationSucceeds(
         arn,
-        personal,
+        Some(personal),
         validNino.value,
         invitationIdPIR,
         validNino.value,
@@ -167,17 +179,17 @@ class AgentMultiInvitationControllerISpec extends BaseISpec with AuthBehaviours 
         "NI")
       givenInvitationCreationSucceeds(
         arn,
-        personal,
+        Some(personal),
         validVrn.value,
         invitationIdVAT,
         validVrn.value,
         "vrn",
         serviceVAT,
         identifierVAT)
-      givenAgentReference(arn, uid, "personal")
+      givenAgentReference(arn, uid, personal)
       givenAgentReferenceRecordExistsForArn(arn, "uid")
 
-      testAgentSessionCache.save(AgentSession(personal, Some(serviceVAT)))
+      testAgentSessionCache.save(AgentSession(Some(personal), Some(serviceVAT)))
 
       val result = controller.submitReviewAuthorisations()(
         authorisedAsValidAgent(request, arn.value).withFormUrlEncodedBody("accepted" -> "false"))
@@ -187,9 +199,10 @@ class AgentMultiInvitationControllerISpec extends BaseISpec with AuthBehaviours 
 
     "Redirect to all create authorisation failed error page if NO is selected and all invitation creations fail" in new AgentAuthorisationFullCacheScenario {
       givenInvitationCreationFails(arn)
-      givenAgentReference(arn, uid, "personal")
+      givenAgentReference(arn, uid, personal)
 
-      testAgentSessionCache.save(AgentSession(personal, Some(serviceVAT), requests = Set(clientDetail1, clientDetail2, clientDetail3)))
+      testAgentSessionCache.save(
+        AgentSession(Some(personal), Some(serviceVAT), requests = Set(clientDetail1, clientDetail2, clientDetail3)))
 
       val result = controller.submitReviewAuthorisations()(
         authorisedAsValidAgent(request, arn.value).withFormUrlEncodedBody("accepted" -> "false"))
@@ -201,7 +214,7 @@ class AgentMultiInvitationControllerISpec extends BaseISpec with AuthBehaviours 
     "Redirect to some create authorisation failed if NO is selected and some invitation creations fail" in new AgentAuthorisationFullCacheScenario {
       givenInvitationCreationSucceeds(
         arn,
-        personal,
+        Some(personal),
         validNino.value,
         invitationIdITSA,
         validNino.value,
@@ -210,7 +223,7 @@ class AgentMultiInvitationControllerISpec extends BaseISpec with AuthBehaviours 
         "NI")
       givenInvitationCreationSucceeds(
         arn,
-        personal,
+        Some(personal),
         validNino.value,
         invitationIdPIR,
         validNino.value,
@@ -219,16 +232,17 @@ class AgentMultiInvitationControllerISpec extends BaseISpec with AuthBehaviours 
         "NI")
       givenInvitationCreationFailsForService(
         arn,
-        Some("personal"),
+        Some(personal),
         validVrn.value,
         invitationIdVAT,
         validVrn.value,
         "vrn",
         serviceVAT,
         identifierVAT)
-      givenAgentReference(arn, uid, "personal")
+      givenAgentReference(arn, uid, personal)
 
-      testAgentSessionCache.save(AgentSession(personal, Some(serviceVAT), requests = Set(clientDetail1, clientDetail2, clientDetail3)))
+      testAgentSessionCache.save(
+        AgentSession(Some(personal), Some(serviceVAT), requests = Set(clientDetail1, clientDetail2, clientDetail3)))
       val result = controller.submitReviewAuthorisations()(
         authorisedAsValidAgent(request, arn.value).withFormUrlEncodedBody("accepted" -> "false"))
 
@@ -237,7 +251,7 @@ class AgentMultiInvitationControllerISpec extends BaseISpec with AuthBehaviours 
     }
 
     "Redisplay the page with errors if no option is chosen" in new AgentAuthorisationFullCacheScenario {
-      testAgentSessionCache.save(AgentSession(personal, Some(serviceVAT)))
+      testAgentSessionCache.save(AgentSession(Some(personal), Some(serviceVAT)))
       val result = controller.submitReviewAuthorisations()(authorisedAsValidAgent(request, arn.value))
       status(result) shouldBe 200
       checkHtmlResultWithBodyText(result, "Select yes if you want to add another authorisation for this client")
@@ -277,7 +291,7 @@ class AgentMultiInvitationControllerISpec extends BaseISpec with AuthBehaviours 
       redirectLocation(result) shouldBe Some(routes.AgentsInvitationController.showReviewAuthorisations().url)
 
       await(testAgentSessionCache.fetch) shouldBe Some(
-        AgentSession(personal,requests=  Set(clientDetail2, clientDetail3)))
+        AgentSession(Some(personal), requests = Set(clientDetail2, clientDetail3)))
     }
 
     "Redirect to review-authorisations page with selected invitation not removed from cache when NO is selected" in new AgentAuthorisationFullCacheScenario {
@@ -288,7 +302,7 @@ class AgentMultiInvitationControllerISpec extends BaseISpec with AuthBehaviours 
       redirectLocation(result) shouldBe Some(routes.AgentsInvitationController.showReviewAuthorisations().url)
 
       await(testAgentSessionCache.fetch) shouldBe Some(
-        AgentSession(personal,requests= Set(clientDetail1, clientDetail2, clientDetail3)))
+        AgentSession(Some(personal), requests = Set(clientDetail1, clientDetail2, clientDetail3)))
 
     }
 
@@ -341,7 +355,7 @@ class AgentMultiInvitationControllerISpec extends BaseISpec with AuthBehaviours 
           ItsaInvitation(validNino, Some(Postcode(validPostcode))),
           AuthorisationRequest.NEW,
           "itemId")
-      testAgentSessionCache.save(AgentSession(personal, Some(serviceITSA), requests = Set(authRequest1)))
+      testAgentSessionCache.save(AgentSession(Some(personal), Some(serviceITSA), requests = Set(authRequest1)))
 
       val result = controller.pendingAuthorisationExists()(authorisedAsValidAgent(request, arn.value))
 
@@ -354,7 +368,7 @@ class AgentMultiInvitationControllerISpec extends BaseISpec with AuthBehaviours 
     }
 
     "Display the pending authorisation already exists error page version when there are no authorisation requests left in the basket" in {
-      testAgentSessionCache.save(AgentSession(personal, Some(serviceVAT)))
+      testAgentSessionCache.save(AgentSession(Some(personal), Some(serviceVAT)))
       val result = controller.pendingAuthorisationExists()(authorisedAsValidAgent(request, arn.value))
 
       status(result) shouldBe 200
@@ -368,7 +382,14 @@ class AgentMultiInvitationControllerISpec extends BaseISpec with AuthBehaviours 
     }
 
     "Display the pending authorisation already exists error page version when coming from fast track" in {
-      testAgentSessionCache.save(AgentSession(personal, Some(serviceVAT), Some("vrn"), Some(validVrn.value), Some(""), fromFastTrack = true))
+      testAgentSessionCache.save(
+        AgentSession(
+          Some(personal),
+          Some(serviceVAT),
+          Some("vrn"),
+          Some(validVrn.value),
+          Some(""),
+          fromFastTrack = true))
       val result = controller.pendingAuthorisationExists()(authorisedAsValidAgent(request, arn.value))
 
       status(result) shouldBe 200
@@ -384,11 +405,15 @@ class AgentMultiInvitationControllerISpec extends BaseISpec with AuthBehaviours 
 
   trait AgentAuthorisationFullCacheScenario {
 
-    val clientDetail1 = AuthorisationRequest("Gareth Gates Sr",  ItsaInvitation(validNino, Some(Postcode(validPostcode))))
-    val clientDetail2 = AuthorisationRequest("Malcolm Pirson",  PirInvitation(validNino, Some(DOB(dateOfBirth))))
-    val clientDetail3 = AuthorisationRequest("Sara Vaterloo", VatInvitation(personal, validVrn, Some(VatRegDate(validRegistrationDate))))
+    val clientDetail1 =
+      AuthorisationRequest("Gareth Gates Sr", ItsaInvitation(validNino, Some(Postcode(validPostcode))))
+    val clientDetail2 = AuthorisationRequest("Malcolm Pirson", PirInvitation(validNino, Some(DOB(dateOfBirth))))
+    val clientDetail3 = AuthorisationRequest(
+      "Sara Vaterloo",
+      VatInvitation(Some(personal), validVrn, Some(VatRegDate(validRegistrationDate))))
 
-    testAgentSessionCache.save(AgentSession(personal, requests =  Set(clientDetail1, clientDetail2, clientDetail3)))
+    testAgentSessionCache.save(
+      AgentSession(Some(personal), requests = Set(clientDetail1, clientDetail2, clientDetail3)))
   }
 
 }

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentTrackRequestsOffFlagISpec.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentTrackRequestsOffFlagISpec.scala
@@ -4,6 +4,7 @@ import com.google.inject.AbstractModule
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.FakeRequest
 import uk.gov.hmrc.agentinvitationsfrontend.models.AgentSession
+import uk.gov.hmrc.agentinvitationsfrontend.models.ClientType.personal
 import uk.gov.hmrc.agentinvitationsfrontend.services.AgentSessionCache
 import uk.gov.hmrc.agentinvitationsfrontend.support.BaseISpec
 import uk.gov.hmrc.http.HeaderCarrier
@@ -48,9 +49,8 @@ class AgentTrackRequestsOffFlagISpec extends BaseISpec {
       .overrides(new TestGuiceModule)
 
   private class TestGuiceModule extends AbstractModule {
-    override def configure(): Unit = {
+    override def configure(): Unit =
       bind(classOf[AgentSessionCache]).toInstance(testAgentSessionCache)
-    }
   }
 
   lazy val controller: AgentsInvitationController = app.injector.instanceOf[AgentsInvitationController]
@@ -68,10 +68,18 @@ class AgentTrackRequestsOffFlagISpec extends BaseISpec {
     val request = FakeRequest("GET", "/agents/invitation-sent")
     val invitationSent = controller.showInvitationSent()
     "return 200 with the only option to continue where user left off" in {
-      givenAgentReference(arn, uid, "personal")
+      givenAgentReference(arn, uid, personal)
       val continueUrl = ContinueUrl("/someITSA/Url")
       testAgentSessionCache.save(
-        AgentSession(personal, Some(serviceITSA), Some("ni"), Some(nino), Some(validPostcode), continueUrl = Some(continueUrl.url), clientTypeForInvitationSent = personal))
+        AgentSession(
+          Some(personal),
+          Some(serviceITSA),
+          Some("ni"),
+          Some(nino),
+          Some(validPostcode),
+          continueUrl = Some(continueUrl.url),
+          clientTypeForInvitationSent = Some(personal)
+        ))
       val result = invitationSent(authorisedAsValidAgent(request, arn.value))
 
       status(result) shouldBe 200
@@ -87,13 +95,21 @@ class AgentTrackRequestsOffFlagISpec extends BaseISpec {
       await(bodyOf(result)) should not include hasMessage("invitation-sent.startNewAuthRequest")
 
       verifyAuthoriseAttempt()
-      await(testAgentSessionCache.get) shouldBe AgentSession(continueUrl = Some(continueUrl.url), clientTypeForInvitationSent = personal)
+      await(testAgentSessionCache.get) shouldBe AgentSession(
+        continueUrl = Some(continueUrl.url),
+        clientTypeForInvitationSent = Some(personal))
     }
 
     "return 200 with two options; agent-services-account and a link to create new invitation" in {
-      givenAgentReference(arn, uid, "personal")
+      givenAgentReference(arn, uid, personal)
       testAgentSessionCache.save(
-        AgentSession(personal, Some(serviceITSA), Some("ni"), Some(nino), Some(validPostcode), clientTypeForInvitationSent = personal))
+        AgentSession(
+          Some(personal),
+          Some(serviceITSA),
+          Some("ni"),
+          Some(nino),
+          Some(validPostcode),
+          clientTypeForInvitationSent = Some(personal)))
       val result = invitationSent(authorisedAsValidAgent(request, arn.value))
 
       status(result) shouldBe 200
@@ -107,7 +123,7 @@ class AgentTrackRequestsOffFlagISpec extends BaseISpec {
       checkHtmlResultWithBodyText(result, htmlEscapedMessage("invitation-sent.continueToASAccount.button"))
       await(bodyOf(result)) should not include hasMessage("invitation-sent.trackRequests.button")
       verifyAuthoriseAttempt()
-      await(testAgentSessionCache.get) shouldBe AgentSession(clientTypeForInvitationSent = personal)
+      await(testAgentSessionCache.get) shouldBe AgentSession(clientTypeForInvitationSent = Some(personal))
     }
 
   }

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentsRequestTrackingControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentsRequestTrackingControllerISpec.scala
@@ -20,6 +20,7 @@ import org.joda.time.{DateTimeZone, LocalDate}
 import org.jsoup.Jsoup
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import uk.gov.hmrc.agentinvitationsfrontend.models.ClientType.personal
 import uk.gov.hmrc.agentinvitationsfrontend.support.BaseISpec
 import uk.gov.hmrc.agentmtdidentifiers.model.{MtdItId, Vrn}
 import uk.gov.hmrc.domain.Nino
@@ -172,10 +173,10 @@ class AgentsRequestTrackingControllerISpec extends BaseISpec with AuthBehaviours
     val postResendLink = controller.submitToResendLink
 
     "return 200 and go to resend link page" in {
-      givenAgentReference(arn, "uid", "personal")
+      givenAgentReference(arn, "uid", personal)
       val expirationDate: String = LocalDate.now(DateTimeZone.UTC).plusDays(14).toString
       val formData =
-        controller.trackInformationForm.fill(TrackResendForm("HMRC-MTD-IT", Some("personal"), expirationDate))
+        controller.trackInformationForm.fill(TrackResendForm("HMRC-MTD-IT", Some(personal), expirationDate))
       val result =
         postResendLink(authorisedAsValidAgent(request.withFormUrlEncodedBody(formData.data.toSeq: _*), arn.value))
 
@@ -194,25 +195,25 @@ class AgentsRequestTrackingControllerISpec extends BaseISpec with AuthBehaviours
 
     "return 400 BadRequest when form data contains errors in service" in {
       val expirationDate: String = LocalDate.now(DateTimeZone.UTC).plusDays(5).toString
-      val formData = controller.trackInformationForm.fill(TrackResendForm("foo", Some("personal"), expirationDate))
+      val formData = controller.trackInformationForm.fill(TrackResendForm("foo", Some(personal), expirationDate))
       val result =
         postResendLink(authorisedAsValidAgent(request.withFormUrlEncodedBody(formData.data.toSeq: _*), arn.value))
 
       status(result) shouldBe 400
     }
 
-    "return 400 BadRequest when form data contains errors in invitationId" in {
-      val expirationDate: String = LocalDate.now(DateTimeZone.UTC).plusDays(5).toString
-      val formData = controller.trackInformationForm.fill(TrackResendForm("HMRC-MTD-IT", Some("foo"), expirationDate))
+    "return 400 BadRequest when form data contains errors in clientType" in {
+      val dataForm = controller.trackInformationForm.bind(
+        Map("service" -> "HMRC-MTD-IT", "clientType" -> "foo", "expiryDate" -> "2019-01-01"))
       val result =
-        postResendLink(authorisedAsValidAgent(request.withFormUrlEncodedBody(formData.data.toSeq: _*), arn.value))
+        postResendLink(authorisedAsValidAgent(request.withFormUrlEncodedBody(dataForm.data.toSeq: _*), arn.value))
 
       status(result) shouldBe 400
     }
 
     "return 400 BadRequest when form data contains errors in expiryDate" in {
       val expirationDate: String = LocalDate.now(DateTimeZone.UTC).plusDays(5).toString
-      val formData = controller.trackInformationForm.fill(TrackResendForm("HMRC-MTD-IT", Some("personal"), "foo"))
+      val formData = controller.trackInformationForm.fill(TrackResendForm("HMRC-MTD-IT", Some(personal), "foo"))
       val result =
         postResendLink(authorisedAsValidAgent(request.withFormUrlEncodedBody(formData.data.toSeq: _*), arn.value))
 

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/stubs/ACAStubs.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/stubs/ACAStubs.scala
@@ -3,7 +3,7 @@ package uk.gov.hmrc.agentinvitationsfrontend.stubs
 import com.github.tomakehurst.wiremock.client.WireMock.{put, status, _}
 import org.joda.time.LocalDate
 import uk.gov.hmrc.agentinvitationsfrontend.UriPathEncoding._
-import uk.gov.hmrc.agentinvitationsfrontend.models.StoredInvitation
+import uk.gov.hmrc.agentinvitationsfrontend.models.{ClientType, StoredInvitation}
 import uk.gov.hmrc.agentinvitationsfrontend.support.WireMockSupport
 import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, InvitationId, Vrn}
 import uk.gov.hmrc.domain.Nino
@@ -11,7 +11,7 @@ import uk.gov.hmrc.domain.Nino
 trait ACAStubs {
   me: WireMockSupport =>
 
-  def givenAgentReference(arn: Arn, uid: String, clientType: String): Any =
+  def givenAgentReference(arn: Arn, uid: String, clientType: ClientType): Any =
     stubFor(
       post(urlEqualTo(
         s"/agent-client-authorisation/agencies/references/arn/${encodePathSegment(arn.value)}/clientType/$clientType"))
@@ -202,7 +202,7 @@ trait ACAStubs {
                          |[]
                          |""".stripMargin)))
 
-  def givenAgentReferenceNotFound(arn: Arn, clientType: String): Unit =
+  def givenAgentReferenceNotFound(arn: Arn, clientType: ClientType): Unit =
     stubFor(
       post(urlEqualTo(
         s"/agent-client-authorisation/agencies/references/arn/${encodePathSegment(arn.value)}/clientType/$clientType"))
@@ -211,7 +211,7 @@ trait ACAStubs {
 
   def givenInvitationCreationSucceeds(
     arn: Arn,
-    clientType: Option[String],
+    clientType: Option[ClientType],
     clientId: String,
     invitationId: InvitationId,
     suppliedClientId: String,
@@ -243,7 +243,7 @@ trait ACAStubs {
 
   def givenInvitationCreationFailsForService(
                                        arn: Arn,
-                                       clientType: Option[String],
+                                       clientType: Option[ClientType],
                                        clientId: String,
                                        invitationId: InvitationId,
                                        suppliedClientId: String,

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/support/TestDataCommonSupport.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/support/TestDataCommonSupport.scala
@@ -31,9 +31,6 @@ trait TestDataCommonSupport {
   val dateOfBirth = "1980-07-07"
   val validVrn9755 = Vrn("101747641")
 
-  val personal = Some("personal")
-  val business = Some("business")
-
   val uid = "X4BZC17W"
   val normalisedAgentName = "99-with-flake"
 

--- a/test/forms/TrackInformationFormSpec.scala
+++ b/test/forms/TrackInformationFormSpec.scala
@@ -21,13 +21,13 @@ import play.api.data.FormError
 import play.api.libs.json.Json
 import uk.gov.hmrc.agentinvitationsfrontend.controllers.TrackResendForm
 import uk.gov.hmrc.agentinvitationsfrontend.controllers.testing.TestEndpointsController._
-import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, InvitationId}
+import uk.gov.hmrc.agentinvitationsfrontend.models.ClientType
 import uk.gov.hmrc.play.test.UnitSpec
 
 class TrackInformationFormSpec extends UnitSpec {
 
   val itsaService = "HMRC-MTD-IT"
-  val clientTypePersonal = Some("personal")
+  val clientTypePersonal = "personal"
   val expiryDate = LocalDate.now(DateTimeZone.UTC).plusDays(5).toString
 
   "ConfirmInvite form" should {
@@ -65,7 +65,7 @@ class TrackInformationFormSpec extends UnitSpec {
 
     "return no errors when unbinding the form" in {
       val unboundForm =
-        testTrackInformationForm.mapping.unbind(TrackResendForm(itsaService, clientTypePersonal, expiryDate))
+        testTrackInformationForm.mapping.unbind(TrackResendForm(itsaService, Some(ClientType.personal), expiryDate))
       unboundForm("service") shouldBe itsaService
       unboundForm("clientType") shouldBe "personal"
       unboundForm("expiryDate") shouldBe expiryDate

--- a/test/models/ClientTypeSpec.scala
+++ b/test/models/ClientTypeSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.json.{JsString, Json, OFormat}
+import uk.gov.hmrc.agentinvitationsfrontend.models.ClientType
+import uk.gov.hmrc.play.test.UnitSpec
+
+class ClientTypeSpec extends UnitSpec {
+
+  case class ClientTypeTest(clientType: ClientType)
+  object ClientTypeTest {
+    implicit val formats: OFormat[ClientTypeTest] = Json.format[ClientTypeTest]
+  }
+
+  "ClientType" should {
+    "serialize to json string" in {
+      Json.toJson(ClientType.personal) shouldBe JsString("personal")
+      Json.toJson(ClientType.business) shouldBe JsString("business")
+    }
+
+    "deserialize from json string" in {
+      Json.parse("""{"clientType":"personal"}""").as[ClientTypeTest].clientType shouldBe ClientType.personal
+      Json.parse("""{"clientType":"business"}""").as[ClientTypeTest].clientType shouldBe ClientType.business
+    }
+
+  }
+}

--- a/test/models/InvitationSpec.scala
+++ b/test/models/InvitationSpec.scala
@@ -17,6 +17,7 @@
 package models
 
 import play.api.libs.json.{JsSuccess, Json}
+import uk.gov.hmrc.agentinvitationsfrontend.models.ClientType.personal
 import uk.gov.hmrc.agentinvitationsfrontend.models._
 import uk.gov.hmrc.agentmtdidentifiers.model.Vrn
 import uk.gov.hmrc.domain.Nino
@@ -48,7 +49,7 @@ class InvitationSpec extends UnitSpec {
 
     "read and write VatInvitation as expected" in {
 
-      val vatInvitation = VatInvitation(Some("personal"), Vrn("329611751"), Some(VatRegDate("10-10-2030")))
+      val vatInvitation = VatInvitation(Some(personal), Vrn("329611751"), Some(VatRegDate("10-10-2030")))
       val jsValue = Json.parse(
         """{"type":"VatInvitation","data":{"clientType":"personal","service":"HMRC-MTD-VAT","clientIdentifier":"329611751","clientIdentifierType":"vrn","vatRegDate":{"value":"10-10-2030"}}}""")
 


### PR DESCRIPTION
This PR is to replace clientType strings with references to the ClientType enum instances. 