### PR TITLE
[AO] refactor MongoSessionStore, inject CacheRepository as a dependency, declare singleton SessionCacheRepository

### DIFF
--- a/app/uk/gov/hmrc/agentinvitationsfrontend/repository/ClientConsentsCache.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/repository/ClientConsentsCache.scala
@@ -24,10 +24,7 @@ import uk.gov.hmrc.agentinvitationsfrontend.models.ClientConsentsJourneyState
 import scala.concurrent.ExecutionContext
 
 @Singleton
-class ClientConsentsCache @Inject()(
-  @Named("mongodb.session.expireAfterSeconds") val expireAfterSeconds: Int,
-  val mongo: ReactiveMongoComponent,
-  implicit val ec: ExecutionContext)
+class ClientConsentsCache @Inject()(val cacheRepository: SessionCacheRepository)
     extends SessionCache[ClientConsentsJourneyState] {
   override val sessionName: String = "clientSession"
 }

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/repository/SessionCache.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/repository/SessionCache.scala
@@ -21,11 +21,11 @@ import play.api.libs.json.{Reads, Writes}
 import uk.gov.hmrc.agentinvitationsfrontend.util.toFuture
 import uk.gov.hmrc.http.HeaderCarrier
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 trait SessionCache[T] extends MongoSessionStore[T] {
 
-  def fetch(implicit hc: HeaderCarrier, reads: Reads[T]): Future[Option[T]] =
+  def fetch(implicit hc: HeaderCarrier, reads: Reads[T], ec: ExecutionContext): Future[Option[T]] =
     get.flatMap {
       case Right(cache) => cache
       case Left(error) =>
@@ -33,7 +33,7 @@ trait SessionCache[T] extends MongoSessionStore[T] {
         Future.failed(new RuntimeException(error))
     }
 
-  def fetchAndClear(implicit hc: HeaderCarrier, reads: Reads[T]): Future[Option[T]] = {
+  def fetchAndClear(implicit hc: HeaderCarrier, reads: Reads[T], ec: ExecutionContext): Future[Option[T]] = {
     val result = for {
       cache <- get
       _     <- delete()
@@ -47,7 +47,7 @@ trait SessionCache[T] extends MongoSessionStore[T] {
     }
   }
 
-  def save(input: T)(implicit hc: HeaderCarrier, writes: Writes[T]): Future[T] =
+  def save(input: T)(implicit hc: HeaderCarrier, writes: Writes[T], ec: ExecutionContext): Future[T] =
     store(input).flatMap {
       case Right(_) => input
       case Left(error) =>
@@ -55,7 +55,7 @@ trait SessionCache[T] extends MongoSessionStore[T] {
         Future.failed(new RuntimeException(error))
     }
 
-  def hardGet(implicit hc: HeaderCarrier, reads: Reads[T]): Future[T] =
+  def hardGet(implicit hc: HeaderCarrier, reads: Reads[T], ec: ExecutionContext): Future[T] =
     fetch.map {
       case Some(entry) => entry
       case None =>

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/repository/SessionCacheRepository.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/repository/SessionCacheRepository.scala
@@ -15,15 +15,14 @@
  */
 
 package uk.gov.hmrc.agentinvitationsfrontend.repository
-
-import com.google.inject.Singleton
-import javax.inject.{Inject, Named}
+import javax.inject.{Inject, Named, Singleton}
 import play.modules.reactivemongo.ReactiveMongoComponent
-import uk.gov.hmrc.agentinvitationsfrontend.models.AgentSession
+import uk.gov.hmrc.cache.repository.CacheMongoRepository
 
 import scala.concurrent.ExecutionContext
 
 @Singleton
-class AgentSessionCache @Inject()(val cacheRepository: SessionCacheRepository) extends SessionCache[AgentSession] {
-  override val sessionName: String = "agentSession"
-}
+class SessionCacheRepository @Inject()(
+  @Named("mongodb.session.expireAfterSeconds") expireAfterSeconds: Int,
+  mongo: ReactiveMongoComponent)(implicit ec: ExecutionContext)
+    extends CacheMongoRepository("sessions", expireAfterSeconds)(mongo.mongoConnector.db, ec)


### PR DESCRIPTION
This PR is to try fix issues caused by lazy cacheRepository initialization, like [here](https://kibana.tools.development.tax.service.gov.uk/app/kibana#/doc/logstash-/logstash-docker_json-2019.03.11/doc?id=wxbhbWkBHEsvd512GmCG&_g=(refreshInterval:(pause:!t,value:0),time:(from:now-1h,mode:quick,to:now)))