### PR TITLE
[APB-3538] FSM: Correcting start of journey

### DIFF
--- a/app/uk/gov/hmrc/agentinvitationsfrontend/repository/MongoSessionStore.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/repository/MongoSessionStore.scala
@@ -30,8 +30,11 @@ trait MongoSessionStore[T] {
   val sessionName: String
   val cacheRepository: CacheRepository
 
+  def getSessionId(implicit hc: HeaderCarrier): Option[String] =
+    hc.sessionId.map(_.value)
+
   def get(implicit reads: Reads[T], hc: HeaderCarrier, ec: ExecutionContext): Future[Either[String, Option[T]]] =
-    hc.sessionId.map(_.value) match {
+    getSessionId match {
       case Some(sessionId) ⇒
         cacheRepository
           .findById(Id(sessionId))
@@ -62,7 +65,7 @@ trait MongoSessionStore[T] {
 
   def store(
     newSession: T)(implicit writes: Writes[T], hc: HeaderCarrier, ec: ExecutionContext): Future[Either[String, Unit]] =
-    hc.sessionId.map(_.value) match {
+    getSessionId match {
       case Some(sessionId) ⇒
         cacheRepository
           .createOrUpdate(Id(sessionId), sessionName, Json.toJson(newSession))
@@ -83,7 +86,7 @@ trait MongoSessionStore[T] {
     }
 
   def delete()(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Either[String, Unit]] =
-    hc.sessionId.map(_.value) match {
+    getSessionId match {
       case Some(sessionId) ⇒
         cacheRepository
           .removeById(Id(sessionId))

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ lazy val scoverageSettings = {
 lazy val compileDeps = Seq(
   ws,
   "uk.gov.hmrc" %% "bootstrap-play-25" % "4.9.0",
-  "uk.gov.hmrc" %% "play-fsm" % "0.17.0-play-25",
+  "uk.gov.hmrc" %% "play-fsm" % "0.23.0-play-25",
   "uk.gov.hmrc" %% "govuk-template" % "5.23.0",
   "uk.gov.hmrc" %% "play-ui" % "7.33.0-play-25",
   "uk.gov.hmrc" %% "agent-mtd-identifiers" % "0.13.0",

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -115,8 +115,8 @@ GET         /all-responses-failed                                               
 GET         /assets/*file                                                        controllers.Assets.at(path="/public", file)
 
 #Journey Client endpoints
-POST         /fsm/warm-up                                                          @uk.gov.hmrc.agentinvitationsfrontend.controllers.ClientInvitationJourneyController.submitWarmUp
-POST         /fsm/warm-up/to-decline                                                          @uk.gov.hmrc.agentinvitationsfrontend.controllers.ClientInvitationJourneyController.submitWarmUpConfirmDecline
+GET          /fsm/warm-up                                                          @uk.gov.hmrc.agentinvitationsfrontend.controllers.ClientInvitationJourneyController.submitWarmUp
+GET          /fsm/warm-up/to-decline                                                          @uk.gov.hmrc.agentinvitationsfrontend.controllers.ClientInvitationJourneyController.submitWarmUpConfirmDecline
 GET          /fsm/not-found                                                     @uk.gov.hmrc.agentinvitationsfrontend.controllers.ClientInvitationJourneyController.showNotFoundInvitation
 GET          /fsm/consent                                                    @uk.gov.hmrc.agentinvitationsfrontend.controllers.ClientInvitationJourneyController.showConsent
 GET          /fsm/consent/individual                                                   @uk.gov.hmrc.agentinvitationsfrontend.controllers.ClientInvitationJourneyController.showConsentIndividual

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentInvitationJourneyControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentInvitationJourneyControllerISpec.scala
@@ -108,7 +108,7 @@ class AgentInvitationJourneyControllerISpec extends BaseISpec with StateAndBread
 
       status(result) shouldBe 303
       redirectLocation(result) shouldBe Some(routes.AgentInvitationJourneyController.showClientType().url)
-      flash(result) shouldBe Flash(Map())
+      flash(result) shouldBe Flash(Map("dummy" -> "")) // "dummy" comes from a workaround introduced in https://github.com/hmrc/play-fsm/releases/tag/v0.20.0
 
       journeyState.get should have[State](SelectClientType(emptyBasket), Nil)
 


### PR DESCRIPTION
Some changes to the FSM based client journey..

Moved the check and redirect to /wrong-account-type from the GET /warm-up endpoint to the POST /warm-up endpoint

Allowed first page of client journey to work when not logged in (by using a journey ID in the http session)