### PR TITLE
[APB-3725][MP] fix some responses failed page in client journey

### DIFF
--- a/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/ClientInvitationJourneyController.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/ClientInvitationJourneyController.scala
@@ -328,7 +328,6 @@ class ClientInvitationJourneyController @Inject()(
           SomeResponsesFailedPageConfig(
             failedConsents,
             agentName,
-            //this call is wrong, what should it be?
             routes.ClientInvitationJourneyController.submitSomeResponsesFailed())))
   }
 }

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/ClientInvitationJourneyController.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/ClientInvitationJourneyController.scala
@@ -202,6 +202,10 @@ class ClientInvitationJourneyController @Inject()(
     case _: SomeResponsesFailed =>
   }
 
+  def submitSomeResponsesFailed = action { implicit request =>
+    whenAuthorised(AsClient)(Transitions.continueSomeResponsesFailed)(redirect)
+  }
+
   val notAuthorised: Action[AnyContent] = Action { implicit request =>
     Forbidden(
       not_authorised(
@@ -318,14 +322,14 @@ class ClientInvitationJourneyController @Inject()(
 
     case AllResponsesFailed => Ok(all_responses_failed())
 
-    case SomeResponsesFailed(agentName, consents) =>
+    case SomeResponsesFailed(agentName, failedConsents, _) =>
       Ok(
         some_responses_failed(
           SomeResponsesFailedPageConfig(
-            consents,
+            failedConsents,
             agentName,
             //this call is wrong, what should it be?
-            routes.ClientInvitationJourneyController.showCheckAnswers())))
+            routes.ClientInvitationJourneyController.submitSomeResponsesFailed())))
   }
 }
 

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/journeys/ClientInvitationJourneyModel.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/journeys/ClientInvitationJourneyModel.scala
@@ -50,7 +50,11 @@ object ClientInvitationJourneyModel extends JourneyModel {
     case class InvitationsAccepted(agentName: String, consents: Seq[ClientConsent]) extends State
     case class InvitationsDeclined(agentName: String, consents: Seq[ClientConsent]) extends State
     case object AllResponsesFailed extends State
-    case class SomeResponsesFailed(agentName: String, consents: Seq[ClientConsent]) extends State
+    case class SomeResponsesFailed(
+      agentName: String,
+      failedConsents: Seq[ClientConsent],
+      successfulConsents: Seq[ClientConsent])
+        extends State
     case class ConfirmDecline(clientType: ClientType, uid: String, agentName: String, consents: Seq[ClientConsent])
         extends State
   }
@@ -192,9 +196,18 @@ object ClientInvitationJourneyModel extends JourneyModel {
                      goto(InvitationsDeclined(agentName, consents))
                    else if (ClientConsent.allAcceptanceFailed(newConsents)) goto(AllResponsesFailed)
                    else if (ClientConsent.someAcceptanceFailed(newConsents))
-                     goto(SomeResponsesFailed(agentName, consents))
+                     goto(
+                       SomeResponsesFailed(
+                         agentName,
+                         newConsents.filter(_.processed == false),
+                         newConsents.filter(_.processed == true)))
                    else goto(InvitationsAccepted(agentName, consents))
         } yield result
+    }
+
+    def continueSomeResponsesFailed(client: AuthorisedClient) = Transition {
+      case SomeResponsesFailed(agentName, _, successfulConsents) =>
+        goto(InvitationsAccepted(agentName, successfulConsents))
     }
 
     def submitCheckAnswersChange(serviceMessageKeyToChange: String)(client: AuthorisedClient) = Transition {

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/some_responses_failed.scala.html
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/some_responses_failed.scala.html
@@ -20,6 +20,7 @@
 @import uk.gov.hmrc.agentinvitationsfrontend.models.ClientConsent
 @import uk.gov.hmrc.agentinvitationsfrontend.controllers.routes
 @import uk.gov.hmrc.agentinvitationsfrontend.views.clients.SomeResponsesFailedPageConfig
+@import uk.gov.hmrc.play.views.html.helpers.form
 
 @(config: SomeResponsesFailedPageConfig)(implicit request: Request[_], messages: Messages, configuration: Configuration, externalUrls: ExternalUrls)
 
@@ -51,6 +52,8 @@
 
   <p>@Messages("some-responses-failed.advice", config.agencyName)</p>
 
-    <a href=@config.acceptInvitationCall class="button">@Messages("continue.button")</a>
+    @form(config.acceptInvitationCall) {
+        <button id="continueToComplete" class="button" type="submit">@Messages("continue.button")</button>
+    }
 
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -143,6 +143,7 @@ GET         /accepted                                                       @uk.
 GET         /declined                                                       @uk.gov.hmrc.agentinvitationsfrontend.controllers.ClientInvitationJourneyController.showInvitationsDeclined
 GET         /all-responses-failed                                           @uk.gov.hmrc.agentinvitationsfrontend.controllers.ClientInvitationJourneyController.showAllResponsesFailed
 GET         /some-responses-failed                                          @uk.gov.hmrc.agentinvitationsfrontend.controllers.ClientInvitationJourneyController.showSomeResponsesFailed
+POST        /some-responses-failed                                          @uk.gov.hmrc.agentinvitationsfrontend.controllers.ClientInvitationJourneyController.submitSomeResponsesFailed
 GET         /not-authorised                                                 @uk.gov.hmrc.agentinvitationsfrontend.controllers.ClientInvitationJourneyController.notAuthorised
 GET         /session-timeout                                                @uk.gov.hmrc.agentinvitationsfrontend.controllers.ClientInvitationJourneyController.showMissingJourneyHistory
 

--- a/conf/messages
+++ b/conf/messages
@@ -464,7 +464,7 @@ wrong-client-type.p3=You can create an account if you do not have one.
 wrong-client-type.button=Sign out and try again
 
 #Some Responses Failed
-some-responses-failed.header=Sorry, some of your responses could not be saved
+some-responses-failed.header=Sorry, there is a problem with the service
 some-responses-failed.p1=We could not save your response for the following services:
 some-responses-failed.li.itsa=Send your Income Tax updates through software
 some-responses-failed.li.afi=View your PAYE income record

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/ClientInvitationJourneyControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/ClientInvitationJourneyControllerISpec.scala
@@ -48,7 +48,8 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
 
     "journey ID is already present in the session cookie, show the warmup page" should {
       "work when signed in" in new Setup {
-        val reqAuthorisedWithJourneyId = authorisedAsAnyIndividualClient(requestWithJourneyIdInCookie("GET", endpointUrl))
+        val reqAuthorisedWithJourneyId =
+          authorisedAsAnyIndividualClient(requestWithJourneyIdInCookie("GET", endpointUrl))
         val result = controller.warmUp("personal", uid, "My-Agency")(reqAuthorisedWithJourneyId)
         checkWarmUpPageIsShown(result)
       }
@@ -61,11 +62,11 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
       def checkWarmUpPageIsShown(result: Result) {
         status(result) shouldBe 200
 
-        checkHtmlResultWithBodyText(result,
+        checkHtmlResultWithBodyText(
+          result,
           htmlEscapedMessage("warm-up.header", "My Agency"),
-          htmlEscapedMessage("warm-up.inset","My Agency")
-        )
-        checkIncludesText(result,"<p>So we can confirm who you are")
+          htmlEscapedMessage("warm-up.inset", "My Agency"))
+        checkIncludesText(result, "<p>So we can confirm who you are")
       }
     }
 
@@ -541,7 +542,7 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
       checkHtmlResultWithBodyText(result, htmlEscapedMessage("all-responses-failed.p"))
     }
   }
-  "GET /warm-up/some-failed" should {
+  "GET /some-responses-failed" should {
     def request = requestWithJourneyIdInCookie("GET", "/warm-up/some-failed")
 
     behave like anActionHandlingSessionExpiry(controller.showSomeResponsesFailed)
@@ -549,14 +550,40 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
     "display the some responses failed page" in {
       journeyState
         .set(
-          SomeResponsesFailed("My Agency", Seq(ClientConsent(invitationIdITSA, expiryDate, "itsa", consent = true))),
-          Nil)
+          SomeResponsesFailed(
+            "My Agency",
+            Seq(ClientConsent(invitationIdITSA, expiryDate, "itsa", consent = true)),
+            Seq(ClientConsent(invitationIdPIR, expiryDate, "afi", consent = true))),
+          Nil
+        )
 
       val result = controller.showSomeResponsesFailed(authorisedAsAnyIndividualClient(request))
       status(result) shouldBe 200
 
       checkHtmlResultWithBodyText(result, htmlEscapedMessage("some-responses-failed.header"))
       checkHtmlResultWithBodyText(result, htmlEscapedMessage("some-responses-failed.itsa"))
+    }
+  }
+
+  "POST /some-responses-failed" should {
+    def request = requestWithJourneyIdInCookie("POST", "/some-responses-failed")
+
+    "redirect to complete page with only successfully processed consents" in {
+      journeyState
+        .set(
+          SomeResponsesFailed(
+            "My Agency",
+            Seq(ClientConsent(invitationIdITSA, expiryDate, "itsa", consent = true)),
+            Seq(ClientConsent(invitationIdPIR, expiryDate, "afi", consent = true))),
+          Nil
+        )
+
+      val result = controller.submitSomeResponsesFailed(authorisedAsAnyIndividualClient(request))
+      status(result) shouldBe 303
+      redirectLocation(result) shouldBe Some(routes.ClientInvitationJourneyController.showInvitationsAccepted().url)
+
+      journeyState.get.get._1 shouldBe
+        InvitationsAccepted("My Agency", Seq(ClientConsent(invitationIdPIR, expiryDate, "afi", consent = true)))
     }
   }
 
@@ -576,7 +603,7 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
     }
   }
 
-  private def anActionHandlingSessionExpiry(action: Action[AnyContent]) = {
+  private def anActionHandlingSessionExpiry(action: Action[AnyContent]) =
     "redirect to /session-timeout if there is no journey ID/history available" when {
       "logged in" in {
         checkRedirectsToSessionExpiry(authorisedAsAnyIndividualClient(FakeRequest()))
@@ -593,5 +620,4 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
         redirectLocation(result) shouldBe Some(routes.ClientInvitationJourneyController.showMissingJourneyHistory().url)
       }
     }
-  }
 }

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/retired/ClientsMultiInvitationsControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/retired/ClientsMultiInvitationsControllerISpec.scala
@@ -1126,7 +1126,7 @@ class ClientsMultiInvitationsControllerISpec extends BaseISpec {
       status(result) shouldBe 200
       checkHtmlResultWithBodyText(
         result,
-        "Sorry, some of your responses could not be saved",
+        "Sorry, there is a problem with the service",
         "We could not save your response for the following services:",
         "Send your Income Tax updates through software",
         "Submit your VAT returns through software",

--- a/test/journeys/ClientInvitationJourneyModelSpec.scala
+++ b/test/journeys/ClientInvitationJourneyModelSpec.scala
@@ -296,9 +296,11 @@ class ClientInvitationJourneyModelSpec extends UnitSpec with StateMatchers[State
           SomeResponsesFailed(
             "agent name",
             Seq(
-              ClientConsent(invitationIdItsa, expiryDate, "itsa", consent = true),
-              ClientConsent(invitationIdIrv, expiryDate, "afi", consent = true),
-              ClientConsent(invitationIdVat, expiryDate, "vat", consent = true)
+              ClientConsent(invitationIdItsa, expiryDate, "itsa", consent = true)
+            ),
+            Seq(
+              ClientConsent(invitationIdIrv, expiryDate, "afi", consent = true, processed = true),
+              ClientConsent(invitationIdVat, expiryDate, "vat", consent = true, processed = true)
             )
           ))
       }
@@ -375,7 +377,20 @@ class ClientInvitationJourneyModelSpec extends UnitSpec with StateMatchers[State
           )
         )
       }
+    }
 
+    "at state SomeResponsesFailed" should {
+      "transition to InvitationsAccepted with successfully processed consents" in {
+        given(
+          SomeResponsesFailed(
+            "Mr agent",
+            Seq(ClientConsent(invitationIdItsa, expiryDate, "itsa", consent = true)),
+            Seq(ClientConsent(invitationIdIrv, expiryDate, "afi", consent = true, processed = true))
+          )) when continueSomeResponsesFailed(authorisedIndividualClient) should thenGo(
+          InvitationsAccepted(
+            "Mr agent",
+            Seq(ClientConsent(InvitationId("B1BEOZEO7MNO6"), expiryDate, "afi", consent = true, processed = true))))
+      }
     }
   }
 }

--- a/test/journeys/ClientInvitationJourneyStateFormatsSpec.scala
+++ b/test/journeys/ClientInvitationJourneyStateFormatsSpec.scala
@@ -227,17 +227,37 @@ class ClientInvitationJourneyStateFormatsSpec extends UnitSpec {
               LocalDate.parse("2010-01-01"),
               "itsa",
               consent = true
-            ),
+            )
+          ),
+          Seq(
             ClientConsent(
               InvitationId("B1BEOZEO7MNO6"),
               LocalDate.parse("2010-02-02"),
               "afi",
-              consent = true
-            )
-          )
+              consent = true,
+              processed = true
+            ))
         )
-        val json = Json.parse(
-          s"""{"state":"SomeResponsesFailed","properties":{"agentName": "agent name", $jsonConsents}}""".stripMargin)
+        val json =
+          Json.parse(s"""{"state":"SomeResponsesFailed","properties":{"agentName": "agent name", 
+               "failedConsents": [{
+                        |  "invitationId": {
+                        |    "value": "A1BEOZEO7MNO6"
+                        |  },
+                        |  "expiryDate": "2010-01-01",
+                        |  "serviceKey": "itsa",
+                        |  "consent": true,
+                        |  "processed": false
+                        |}],
+                        |"successfulConsents": [{
+                        |  "invitationId": {
+                        |    "value": "B1BEOZEO7MNO6"
+                        |  },
+                        |  "expiryDate": "2010-02-02",
+                        |  "serviceKey": "afi",
+                        |  "consent": true,
+                        |  "processed": true
+                        |}]}}""".stripMargin)
 
         Json.toJson(state) shouldBe json
         json.as[State] shouldBe state


### PR DESCRIPTION
fix is to only show services that have failed on the some responses failed page and continue through to complete page with only services that have succeeded, with tests.