### PR TITLE
[APB-4243][MP] Refactor client type and select service forms to show custom error messages

### DIFF
--- a/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentInvitationFastTrackJourneyController.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentInvitationFastTrackJourneyController.scala
@@ -534,9 +534,12 @@ object AgentInvitationFastTrackJourneyController {
 
   val SelectClientTypeForm: Form[String] = Form(
     single(
-      "clientType" -> lowerCaseText.verifying("client.type.invalid", Set("personal", "business").contains _)
-    )
-  )
+      "clientType" -> optional(lowerCaseText)
+        .verifying(
+          "error.fast-track.client-type.empty",
+          clientTypeOpt => Set("personal", "business").contains(clientTypeOpt.getOrElse("")))
+        .transform(_.getOrElse(""), (Some(_)): String => Option[String])
+    ))
 
   def confirmationForm(errorMessage: String): Form[Confirmation] =
     Form(

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentInvitationFastTrackJourneyController.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentInvitationFastTrackJourneyController.scala
@@ -27,7 +27,7 @@ import play.api.mvc._
 import uk.gov.hmrc.agentinvitationsfrontend.config.ExternalUrls
 import uk.gov.hmrc.agentinvitationsfrontend.connectors.{AgentServicesAccountConnector, InvitationsConnector}
 import uk.gov.hmrc.agentinvitationsfrontend.controllers.AgentInvitationJourneyController.ConfirmClientForm
-import uk.gov.hmrc.agentinvitationsfrontend.forms.TrustClientForm
+import uk.gov.hmrc.agentinvitationsfrontend.forms.{ClientTypeForm, TrustClientForm}
 import uk.gov.hmrc.agentinvitationsfrontend.journeys.AgentInvitationFastTrackJourneyService
 import uk.gov.hmrc.agentinvitationsfrontend.models.ClientType.{business, personal}
 import uk.gov.hmrc.agentinvitationsfrontend.models.Services._
@@ -205,7 +205,7 @@ class AgentInvitationFastTrackJourneyController @Inject()(
   }
 
   val submitClientType = action { implicit request =>
-    whenAuthorisedWithForm(AsAgent)(SelectClientTypeForm)(
+    whenAuthorisedWithForm(AsAgent)(ClientTypeForm.fastTrackForm)(
       Transitions.selectedClientType(checkPostcodeMatches)(checkCitizenRecordMatches)(checkVatRegistrationDateMatches)(
         createInvitation)(createAgentLink)(getAgencyEmail)(hasPendingInvitationsFor)(hasActiveRelationshipFor))
   }
@@ -362,7 +362,7 @@ class AgentInvitationFastTrackJourneyController @Inject()(
     case SelectClientTypeVat(_, _, _) =>
       Ok(
         client_type(
-          formWithErrors.or(SelectClientTypeForm),
+          formWithErrors.or(ClientTypeForm.fastTrackForm),
           ClientTypePageConfig(
             backLinkFor(breadcrumbs).url,
             routes.AgentInvitationFastTrackJourneyController.submitClientType(),
@@ -531,15 +531,6 @@ object AgentInvitationFastTrackJourneyController {
             request.clientIdentifier,
             request.knownFact))
       }).verifying(validateFastTrackForm))
-
-  val SelectClientTypeForm: Form[String] = Form(
-    single(
-      "clientType" -> optional(lowerCaseText)
-        .verifying(
-          "error.fast-track.client-type.empty",
-          clientTypeOpt => Set("personal", "business").contains(clientTypeOpt.getOrElse("")))
-        .transform(_.getOrElse(""), (Some(_)): String => Option[String])
-    ))
 
   def confirmationForm(errorMessage: String): Form[Confirmation] =
     Form(

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentInvitationJourneyController.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentInvitationJourneyController.scala
@@ -79,7 +79,7 @@ class AgentInvitationJourneyController @Inject()(
   }
 
   val submitClientType = action { implicit request =>
-    whenAuthorisedWithForm(AsAgent)(ClientTypeForm.form)(Transitions.selectedClientType)
+    whenAuthorisedWithForm(AsAgent)(ClientTypeForm.authorisationForm)(Transitions.selectedClientType)
   }
 
   val showSelectService = actionShowStateWhenAuthorised(AsAgent) {
@@ -232,7 +232,7 @@ class AgentInvitationJourneyController @Inject()(
 
       Ok(
         client_type(
-          formWithErrors.or(ClientTypeForm.form),
+          formWithErrors.or(ClientTypeForm.authorisationForm),
           ClientTypePageConfig(
             backLinkForClientType,
             routes.AgentInvitationJourneyController.submitClientType(),

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentLedDeauthJourneyController.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentLedDeauthJourneyController.scala
@@ -74,7 +74,7 @@ class AgentLedDeauthJourneyController @Inject()(
     }
 
   val submitClientType: Action[AnyContent] = action { implicit request =>
-    whenAuthorisedWithForm(AsAgent)(ClientTypeForm.form)(selectedClientType)
+    whenAuthorisedWithForm(AsAgent)(ClientTypeForm.deAuthorisationForm)(selectedClientType)
   }
 
   val showSelectService: Action[AnyContent] = actionShowStateWhenAuthorised(AsAgent) {
@@ -204,7 +204,7 @@ class AgentLedDeauthJourneyController @Inject()(
 
       Ok(
         client_type(
-          formWithErrors.or(ClientTypeForm.form),
+          formWithErrors.or(ClientTypeForm.deAuthorisationForm),
           ClientTypePageConfig(
             backLinkForClientType,
             routes.AgentLedDeauthJourneyController.submitClientType(),

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/forms/ClientTypeForm.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/forms/ClientTypeForm.scala
@@ -21,18 +21,23 @@ import play.api.data._
 import uk.gov.hmrc.agentinvitationsfrontend.validators.Validators.lowerCaseText
 
 object ClientTypeForm {
-  def form(emptyErrorMsg: String): Form[String] =
+  def form(emptyErrorMsg: String, clientTypes: Set[String]): Form[String] =
     Form[String](
       single(
         "clientType" -> optional(lowerCaseText)
-          .verifying(emptyErrorMsg, ct => supportedClientTypes.contains(ct.getOrElse("")))
+          .verifying(emptyErrorMsg, ct => clientTypes.contains(ct.getOrElse("")))
           .transform(_.getOrElse(""), (Some(_)): String => Option[String])
       )
     )
 
   val supportedClientTypes: Set[String] = Set("personal", "business", "trust")
 
-  lazy val authorisationForm: Form[String] = form("error.client-type.empty")
+  val supportedClientTypesFastTrack: Set[String] = Set("personal", "business")
 
-  lazy val deAuthorisationForm: Form[String] = form("error.cancel-authorisation.client-type.empty")
+  lazy val authorisationForm: Form[String] = form("error.client-type.empty", supportedClientTypes)
+
+  lazy val deAuthorisationForm: Form[String] =
+    form("error.cancel-authorisation.client-type.empty", supportedClientTypes)
+
+  lazy val fastTrackForm: Form[String] = form("error.fast-track.client-type.empty", supportedClientTypesFastTrack)
 }

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/forms/ClientTypeForm.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/forms/ClientTypeForm.scala
@@ -18,13 +18,18 @@ package uk.gov.hmrc.agentinvitationsfrontend.forms
 
 import play.api.data.Forms._
 import play.api.data._
-import uk.gov.hmrc.agentinvitationsfrontend.models.ClientType
 import uk.gov.hmrc.agentinvitationsfrontend.validators.Validators.lowerCaseText
 
 object ClientTypeForm {
-  val form: Form[String] = Form(
-    single(
-      "clientType" -> lowerCaseText.verifying("client.type.invalid", Set("personal", "business", "trust").contains _)
+  def form(emptyErrorMsg: String): Form[String] =
+    Form[String](
+      mapping(
+        "clientType" -> optional(lowerCaseText)
+          .verifying(emptyErrorMsg, ct => ct.contains("personal") || ct.contains("business") || ct.contains("trust"))
+      )(ct => ct.get)(c => Some(Some(c)))
     )
-  )
+
+  lazy val authorisationForm: Form[String] = form("error.client-type.empty")
+
+  lazy val deAuthorisationForm: Form[String] = form("error.cancel-authorisation.client-type.empty")
 }

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/forms/ClientTypeForm.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/forms/ClientTypeForm.scala
@@ -23,11 +23,14 @@ import uk.gov.hmrc.agentinvitationsfrontend.validators.Validators.lowerCaseText
 object ClientTypeForm {
   def form(emptyErrorMsg: String): Form[String] =
     Form[String](
-      mapping(
+      single(
         "clientType" -> optional(lowerCaseText)
-          .verifying(emptyErrorMsg, ct => ct.contains("personal") || ct.contains("business") || ct.contains("trust"))
-      )(ct => ct.get)(c => Some(Some(c)))
+          .verifying(emptyErrorMsg, ct => supportedClientTypes.contains(ct.getOrElse("")))
+          .transform(_.getOrElse(""), (Some(_)): String => Option[String])
+      )
     )
+
+  val supportedClientTypes: Set[String] = Set("personal", "business", "trust")
 
   lazy val authorisationForm: Form[String] = form("error.client-type.empty")
 

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/forms/ServiceTypeForm.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/forms/ServiceTypeForm.scala
@@ -17,13 +17,17 @@
 package uk.gov.hmrc.agentinvitationsfrontend.forms
 
 import play.api.data.Forms._
-import play.api.data._
+import play.api.data.Form
 import uk.gov.hmrc.agentinvitationsfrontend.models.Services.supportedServices
 
 object ServiceTypeForm {
-  val form = Form(
-    single(
-      "serviceType" -> text.verifying("service.type.invalid", supportedServices.contains _)
+
+  val form: Form[String] =
+    Form[String](
+      single(
+        "serviceType" -> optional(text)
+          .verifying("service.type.invalid", serviceOpt => supportedServices.contains(serviceOpt.getOrElse("")))
+          .transform(_.getOrElse(""), (Some(_)): String => Option[String])
+      )
     )
-  )
 }

--- a/conf/messages
+++ b/conf/messages
@@ -16,7 +16,7 @@ client-type.p1=If you need authorisation to deal with both your client''s busine
 client-type.personal=An individual or sole trader
 client-type.business=A company or partnership
 client-type.trust=A trust or an estate
-error.client-type.required=Select the type of client you need authorisation from
+error.client-type.empty=Select if the type of client you need authorisation from is an individual or sole trader, a limited company or partnership, or a trust or an estate
 
 # Identify Client
 identify-client.header=Enter your client''s details
@@ -181,6 +181,8 @@ error.review-authorisation.required=Select yes if you want to add another author
 # Agent led de-auth
 cancel-authorisation.client-type.header=What type of client do you want to cancel your authorisation for?
 cancel-authorisation.client-type.p1=If you need to cancel your authorisation for both a client''s business and personal tax affairs, you need to do these separately.
+error.cancel-authorisation.client-type.empty=Select if the type of client you need to cancel your authorisation for is an individual or sole trader, a limited company or partnership, or a trust or an estate
+
 cancel-authorisation.select-service.header=Which authorisation do you want to cancel for this client?
 cancel-authorisation.select-service.itsa=Sending their Income Tax updates through software
 cancel-authorisation.select-service.vat=Submitting their VAT returns through software

--- a/conf/messages
+++ b/conf/messages
@@ -182,6 +182,7 @@ error.review-authorisation.required=Select yes if you want to add another author
 cancel-authorisation.client-type.header=What type of client do you want to cancel your authorisation for?
 cancel-authorisation.client-type.p1=If you need to cancel your authorisation for both a client''s business and personal tax affairs, you need to do these separately.
 error.cancel-authorisation.client-type.empty=Select if the type of client you need to cancel your authorisation for is an individual or sole trader, a limited company or partnership, or a trust or an estate
+error.fast-track.client-type.empty=Select if the type of client you need to cancel your authorisation for is an individual or sole trader or a limited company or partnership
 
 cancel-authorisation.select-service.header=Which authorisation do you want to cancel for this client?
 cancel-authorisation.select-service.itsa=Sending their Income Tax updates through software

--- a/test/forms/AgentSelectClientTypeFormSpec.scala
+++ b/test/forms/AgentSelectClientTypeFormSpec.scala
@@ -28,25 +28,25 @@ class AgentSelectClientTypeFormSpec extends UnitSpec {
   "ClientType Form" should {
     "return no error message for valid clientType personal" in {
       val data = Json.obj("clientType" -> "personal")
-      val clientTypeWithTrustsForm = ClientTypeForm.form.bind(data)
+      val clientTypeWithTrustsForm = ClientTypeForm.authorisationForm.bind(data)
       clientTypeWithTrustsForm.errors.isEmpty shouldBe true
     }
 
     "return no error message for valid clientType business" in {
       val data = Json.obj("clientType" -> "business")
-      val clientTypeWithTrustsForm = ClientTypeForm.form.bind(data)
+      val clientTypeWithTrustsForm = ClientTypeForm.authorisationForm.bind(data)
       clientTypeWithTrustsForm.errors.isEmpty shouldBe true
     }
 
     "return no error message for valid clientType trust" in {
       val data = Json.obj("clientType" -> "trust")
-      val clientTypeWithTrustsForm = ClientTypeForm.form.bind(data)
+      val clientTypeWithTrustsForm = ClientTypeForm.authorisationForm.bind(data)
       clientTypeWithTrustsForm.errors.isEmpty shouldBe true
     }
 
     "return an error message for form with empty clientType" in {
       val data = Json.obj("clientType" -> "")
-      val clientTypeWithTrustsForm = ClientTypeForm.form.bind(data)
+      val clientTypeWithTrustsForm = ClientTypeForm.authorisationForm.bind(data)
       clientTypeWithTrustsForm.errors.contains(clientTypeEmptyFormError) shouldBe true
       clientTypeWithTrustsForm.errors.length shouldBe 1
     }

--- a/test/forms/AgentSelectClientTypeFormSpec.scala
+++ b/test/forms/AgentSelectClientTypeFormSpec.scala
@@ -22,8 +22,9 @@ import uk.gov.hmrc.play.test.UnitSpec
 
 class AgentSelectClientTypeFormSpec extends UnitSpec {
 
-  val clientTypeEmptyMessage: String = "client.type.invalid"
-  val clientTypeEmptyFormError: FormError = FormError("clientType", List(clientTypeEmptyMessage))
+  val authorisationClientTypeEmptyMessage: String = "error.client-type.empty"
+  val deauthorisationClientTypeEmptyMessage: String = "error.cancel-authorisation.client-type.empty"
+  def clientTypeEmptyFormError(emptyError: String): FormError = FormError("clientType", List(emptyError))
 
   "ClientType Form" should {
     "return no error message for valid clientType personal" in {
@@ -44,10 +45,17 @@ class AgentSelectClientTypeFormSpec extends UnitSpec {
       clientTypeWithTrustsForm.errors.isEmpty shouldBe true
     }
 
-    "return an error message for form with empty clientType" in {
+    "return an error message for an authorisation form with empty clientType" in {
       val data = Json.obj("clientType" -> "")
       val clientTypeWithTrustsForm = ClientTypeForm.authorisationForm.bind(data)
-      clientTypeWithTrustsForm.errors.contains(clientTypeEmptyFormError) shouldBe true
+      clientTypeWithTrustsForm.errors.contains(clientTypeEmptyFormError(authorisationClientTypeEmptyMessage)) shouldBe true
+      clientTypeWithTrustsForm.errors.length shouldBe 1
+    }
+
+    "return an error message for a deauthorisation form with empty clientType" in {
+      val data = Json.obj("clientType" -> "")
+      val clientTypeWithTrustsForm = ClientTypeForm.deAuthorisationForm.bind(data)
+      clientTypeWithTrustsForm.errors.contains(clientTypeEmptyFormError(deauthorisationClientTypeEmptyMessage)) shouldBe true
       clientTypeWithTrustsForm.errors.length shouldBe 1
     }
   }


### PR DESCRIPTION
Because the forms were using non optional mappings on the clientType and service fields within these forms when no value is passed through it was failing and using the default error messages without even getting to field validation. By making the field optional we can use out own custom error messages for an empty field.