### PR TITLE
[APB-4382][MP] fix try again button on known fact not matched page

### DIFF
--- a/app/uk/gov/hmrc/agentinvitationsfrontend/journeys/AgentInvitationFastTrackJourneyModel.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/journeys/AgentInvitationFastTrackJourneyModel.scala
@@ -580,8 +580,7 @@ object AgentInvitationFastTrackJourneyModel extends JourneyModel {
 
           val tryAgainState = fastTrackRequest match {
             case AgentFastTrackRequest(None, HMRCMTDVAT, _, _, _) =>
-              val ftrWithoutKFOrClientType = ftrWithoutKF.copy(clientType = None)
-              SelectClientTypeVat(originalFtr, ftrWithoutKFOrClientType, continueUrl)
+              SelectClientTypeVat(originalFtr, fastTrackRequest, continueUrl)
             case AgentFastTrackRequest(_, service, _, _, _) =>
               stateForMissingKnownFact(service)
           }

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/journeys/AgentInvitationFastTrackJourneyModel.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/journeys/AgentInvitationFastTrackJourneyModel.scala
@@ -578,15 +578,11 @@ object AgentInvitationFastTrackJourneyModel extends JourneyModel {
               case HMRCPIR    => NoDob(originalFtr, ftrWithoutKF, continueUrl)
             }
 
-          val tryAgainState = originalFtr match {
+          val tryAgainState = fastTrackRequest match {
             case AgentFastTrackRequest(None, HMRCMTDVAT, _, _, _) =>
               val ftrWithoutKFOrClientType = ftrWithoutKF.copy(clientType = None)
               SelectClientTypeVat(originalFtr, ftrWithoutKFOrClientType, continueUrl)
-            case AgentFastTrackRequest(Some(_), HMRCMTDVAT, _, _, None) =>
-              stateForMissingKnownFact(HMRCMTDVAT)
-            case AgentFastTrackRequest(_, _, _, _, Some(_)) =>
-              TryAgainWithoutFastTrack
-            case AgentFastTrackRequest(_, service, _, _, None) =>
+            case AgentFastTrackRequest(_, service, _, _, _) =>
               stateForMissingKnownFact(service)
           }
 

--- a/test/journeys/AgentInvitationFastTrackJourneyModelSpec.scala
+++ b/test/journeys/AgentInvitationFastTrackJourneyModelSpec.scala
@@ -592,7 +592,7 @@ class AgentInvitationFastTrackJourneyModelSpec extends UnitSpec with StateMatche
 
       "original request was for MTD-VAT" when {
         val completedPersonalVatFastTrack = AgentFastTrackRequest(
-          clientType = Some(ClientType.personal),
+          clientType = None,
           service = HMRCMTDVAT,
           "vrn",
           vrn,

--- a/test/journeys/AgentInvitationFastTrackJourneyModelSpec.scala
+++ b/test/journeys/AgentInvitationFastTrackJourneyModelSpec.scala
@@ -589,230 +589,132 @@ class AgentInvitationFastTrackJourneyModelSpec extends UnitSpec with StateMatche
     }
 
     "at KnownFactNotMatched, calling tryAgainNotMatchedKnownFact" when {
-
-      "original request was for MTD-VAT" when {
-        val completedPersonalVatFastTrack = AgentFastTrackRequest(
-          clientType = None,
+      "fast track request is for MTD-VAT and client type is missing should go to SelectClientTypeVat" in {
+        val originalFtr = AgentFastTrackRequest(
+          clientType = Some(personal),
           service = HMRCMTDVAT,
           "vrn",
           vrn,
           knownFact = Some("2001-01-01")
         )
 
-        "clientType was missing" when {
-          "known fact was missing, transition to SelectClientTypeVat" in {
-            val originalFastTrackRequest = completedPersonalVatFastTrack.copy(
-              clientType = None,
-              knownFact = None
-            )
-            val knownFactNotMatchedState = KnownFactNotMatched(
-              originalFastTrackRequest = originalFastTrackRequest,
-              fastTrackRequest = completedPersonalVatFastTrack,
+        val ftr = AgentFastTrackRequest(
+          clientType = None,
+          service = HMRCMTDVAT,
+          "vrn",
+          vrn,
+          knownFact = None
+        )
+
+        given(
+          KnownFactNotMatched(
+            originalFastTrackRequest = originalFtr,
+            fastTrackRequest = ftr,
+            continueUrl = None
+          )) when
+          tryAgainNotMatchedKnownFact(authorisedAgent) should
+          thenGo(
+            SelectClientTypeVat(
+              originalFastTrackRequest = originalFtr,
+              fastTrackRequest = ftr,
               continueUrl = None
-            )
-
-            val expectedFinalState = SelectClientTypeVat(
-              originalFastTrackRequest = originalFastTrackRequest,
-              fastTrackRequest = originalFastTrackRequest,
-              continueUrl = None
-            )
-
-            given(knownFactNotMatchedState) when
-              tryAgainNotMatchedKnownFact(authorisedAgent) should
-              thenGo(expectedFinalState)
-          }
-          "known fact was supplied but wrong, transition to SelectClientTypeVat" in {
-            val originalFastTrackRequest = completedPersonalVatFastTrack.copy(
-              clientType = None,
-              knownFact = Some("2001-01-01")
-            )
-            val knownFactNotMatchedState = KnownFactNotMatched(
-              originalFastTrackRequest = originalFastTrackRequest,
-              fastTrackRequest = completedPersonalVatFastTrack,
-              continueUrl = None
-            )
-
-            val expectedFinalState = SelectClientTypeVat(
-              originalFastTrackRequest = originalFastTrackRequest,
-              fastTrackRequest = originalFastTrackRequest.copy(knownFact = None),
-              continueUrl = None
-            )
-
-            given(knownFactNotMatchedState) when
-              tryAgainNotMatchedKnownFact(authorisedAgent) should
-              thenGo(expectedFinalState)
-          }
-        }
-
-        "clientType was personal" when {
-          "known fact was missing, transition to NoVatRegDate" in {
-            val originalFastTrackRequest = completedPersonalVatFastTrack.copy(
-              knownFact = None
-            )
-            val knownFactNotMatchedState = KnownFactNotMatched(
-              originalFastTrackRequest = originalFastTrackRequest,
-              fastTrackRequest = completedPersonalVatFastTrack,
-              continueUrl = None
-            )
-
-            val expectedFinalState = NoVatRegDate(
-              originalFastTrackRequest = originalFastTrackRequest,
-              fastTrackRequest = originalFastTrackRequest,
-              continueUrl = None
-            )
-
-            given(knownFactNotMatchedState) when
-              tryAgainNotMatchedKnownFact(authorisedAgent) should
-              thenGo(expectedFinalState)
-          }
-          "known fact was supplied but wrong, transition to TryAgainWithoutFastTrack" in {
-            val originalFastTrackRequest = completedPersonalVatFastTrack.copy(
-              knownFact = Some("2001-01-01")
-            )
-            val knownFactNotMatchedState = KnownFactNotMatched(
-              originalFastTrackRequest = originalFastTrackRequest,
-              fastTrackRequest = completedPersonalVatFastTrack,
-              continueUrl = None
-            )
-
-            given(knownFactNotMatchedState) when
-              tryAgainNotMatchedKnownFact(authorisedAgent) should
-              thenGo(TryAgainWithoutFastTrack)
-          }
-        }
-
-        "clientType was business" when {
-          val completedBusinessVatFastTrack = completedPersonalVatFastTrack.copy(
-            clientType = Some(ClientType.business)
-          )
-
-          "known fact was missing, transition to NoVatRegDate" in {
-            val originalFastTrackRequest = completedBusinessVatFastTrack.copy(
-              knownFact = None
-            )
-            val knownFactNotMatchedState = KnownFactNotMatched(
-              originalFastTrackRequest = originalFastTrackRequest,
-              fastTrackRequest = completedBusinessVatFastTrack,
-              continueUrl = None
-            )
-
-            val expectedFinalState = NoVatRegDate(
-              originalFastTrackRequest = originalFastTrackRequest,
-              fastTrackRequest = originalFastTrackRequest,
-              continueUrl = None
-            )
-
-            given(knownFactNotMatchedState) when
-              tryAgainNotMatchedKnownFact(authorisedAgent) should
-              thenGo(expectedFinalState)
-          }
-          "known fact was supplied but wrong, transition to TryAgainWithoutFastTrack" in {
-            val originalFastTrackRequest = completedBusinessVatFastTrack.copy(
-              knownFact = Some("2001-01-01")
-            )
-            val knownFactNotMatchedState = KnownFactNotMatched(
-              originalFastTrackRequest = originalFastTrackRequest,
-              fastTrackRequest = completedBusinessVatFastTrack,
-              continueUrl = None
-            )
-
-            given(knownFactNotMatchedState) when
-              tryAgainNotMatchedKnownFact(authorisedAgent) should
-              thenGo(TryAgainWithoutFastTrack)
-          }
-        }
+            ))
       }
 
-      "original request was for MTD-IT service (and clientType was personal)" when {
-        val completedItsaFastTrack = AgentFastTrackRequest(
-          clientType = Some(ClientType.personal),
+      "fast track request is for MTD-VAT with client type should go to NoVatRegDate" in {
+        val originalFtr = AgentFastTrackRequest(
+          clientType = Some(personal),
+          service = HMRCMTDVAT,
+          "vrn",
+          vrn,
+          knownFact = Some("2001-01-01")
+        )
+
+        val ftr = AgentFastTrackRequest(
+          clientType = Some(personal),
+          service = HMRCMTDVAT,
+          "vrn",
+          vrn,
+          knownFact = None
+        )
+
+        given(
+          KnownFactNotMatched(
+            originalFastTrackRequest = originalFtr,
+            fastTrackRequest = ftr,
+            continueUrl = None
+          )) when
+          tryAgainNotMatchedKnownFact(authorisedAgent) should
+          thenGo(
+            NoVatRegDate(
+              originalFastTrackRequest = originalFtr,
+              fastTrackRequest = ftr,
+              continueUrl = None
+            ))
+      }
+
+      "fat track request is for MTD-IT service (and clientType was personal)" in {
+        val originalFtr = AgentFastTrackRequest(
+          clientType = Some(personal),
           service = HMRCMTDIT,
           "ni",
           nino,
           knownFact = Some("AA11AA")
         )
 
-        "knownFact was missing, transition to NoPostcode" in {
-          val originalFastTrackRequest = completedItsaFastTrack.copy(
-            knownFact = None
-          )
-          val knownFactNotMatchedState = KnownFactNotMatched(
-            originalFastTrackRequest = originalFastTrackRequest,
-            fastTrackRequest = completedItsaFastTrack,
+        val ftr = AgentFastTrackRequest(
+          clientType = Some(personal),
+          service = HMRCMTDIT,
+          "ni",
+          nino,
+          knownFact = None
+        )
+
+        given(
+          KnownFactNotMatched(
+            originalFastTrackRequest = originalFtr,
+            fastTrackRequest = ftr,
             continueUrl = None
-          )
-
-          val expectedFinalState = NoPostcode(
-            originalFastTrackRequest = originalFastTrackRequest,
-            fastTrackRequest = originalFastTrackRequest,
-            continueUrl = None
-          )
-
-          given(knownFactNotMatchedState) when
-            tryAgainNotMatchedKnownFact(authorisedAgent) should
-            thenGo(expectedFinalState)
-        }
-
-        "knownFact was supplied but wrong, transition to TryAgainWithoutFastTrack" in {
-          val originalFastTrackRequest = completedItsaFastTrack.copy(
-            knownFact = Some("AA11AA")
-          )
-          val knownFactNotMatchedState = KnownFactNotMatched(
-            originalFastTrackRequest = originalFastTrackRequest,
-            fastTrackRequest = completedItsaFastTrack,
-            continueUrl = None
-          )
-
-          given(knownFactNotMatchedState) when
-            tryAgainNotMatchedKnownFact(authorisedAgent) should
-            thenGo(TryAgainWithoutFastTrack)
-        }
+          )) when
+          tryAgainNotMatchedKnownFact(authorisedAgent) should
+          thenGo(
+            NoPostcode(
+              originalFastTrackRequest = originalFtr,
+              fastTrackRequest = ftr,
+              continueUrl = None
+            ))
       }
 
-      "original request was for IRV service (and clientType was personal)" when {
-        val completedIrvFastTrack = AgentFastTrackRequest(
-          clientType = Some(ClientType.personal),
+      "original request was for IRV service (and clientType was personal)" in {
+        val originalFtr = AgentFastTrackRequest(
+          clientType = Some(personal),
           service = HMRCPIR,
           "ni",
           nino,
-          knownFact = Some("AA11AA")
+          knownFact = Some("1990-09-09")
         )
 
-        "knownFact was missing, transition to NoDob" in {
-          val originalFastTrackRequest = completedIrvFastTrack.copy(
-            knownFact = None
-          )
-          val knownFactNotMatchedState = KnownFactNotMatched(
-            originalFastTrackRequest = originalFastTrackRequest,
-            fastTrackRequest = completedIrvFastTrack,
+        val ftr = AgentFastTrackRequest(
+          clientType = Some(personal),
+          service = HMRCPIR,
+          "ni",
+          nino,
+          knownFact = None
+        )
+
+        given(
+          KnownFactNotMatched(
+            originalFastTrackRequest = originalFtr,
+            fastTrackRequest = ftr,
             continueUrl = None
-          )
-
-          val expectedFinalState = NoDob(
-            originalFastTrackRequest = originalFastTrackRequest,
-            fastTrackRequest = originalFastTrackRequest,
-            continueUrl = None
-          )
-
-          given(knownFactNotMatchedState) when
-            tryAgainNotMatchedKnownFact(authorisedAgent) should
-            thenGo(expectedFinalState)
-        }
-
-        "knownFact was supplied but wrong, transition to TryAgainWithoutFastTrack" in {
-          val originalFastTrackRequest = completedIrvFastTrack.copy(
-            knownFact = Some("2000-01-01")
-          )
-          val knownFactNotMatchedState = KnownFactNotMatched(
-            originalFastTrackRequest = originalFastTrackRequest,
-            fastTrackRequest = completedIrvFastTrack,
-            continueUrl = None
-          )
-
-          given(knownFactNotMatchedState) when
-            tryAgainNotMatchedKnownFact(authorisedAgent) should
-            thenGo(TryAgainWithoutFastTrack)
-        }
+          )) when
+          tryAgainNotMatchedKnownFact(authorisedAgent) should
+          thenGo(
+            NoDob(
+              originalFastTrackRequest = originalFtr,
+              fastTrackRequest = ftr,
+              continueUrl = None
+            ))
       }
 
       "original request was for a Trust service" when {

--- a/test/journeys/AgentInvitationFastTrackJourneyModelSpec.scala
+++ b/test/journeys/AgentInvitationFastTrackJourneyModelSpec.scala
@@ -653,7 +653,7 @@ class AgentInvitationFastTrackJourneyModelSpec extends UnitSpec with StateMatche
             ))
       }
 
-      "fat track request is for MTD-IT service (and clientType was personal)" in {
+      "fast track request is for MTD-IT service (and clientType was personal)" in {
         val originalFtr = AgentFastTrackRequest(
           clientType = Some(personal),
           service = HMRCMTDIT,


### PR DESCRIPTION
When the known fact does not match after submitting check answers from here the user sees a known fact not matched error page. When they click try again they are taken to the respective known fact page for the service they are in and can try to enter the correct one.
This simplifies the logic, before it was directing them out of fast track to start the journey again. 