### PR TITLE
[APB-4290-1][GW] use a success query param inside the failure url for…

### DIFF
--- a/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/ClientInvitationJourneyController.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/ClientInvitationJourneyController.scala
@@ -191,7 +191,7 @@ class ClientInvitationJourneyController @Inject()(
     }
   }
 
-  def signedOut(success: Option[String]): Action[AnyContent] = Action.async { implicit request =>
+  def handleIVTimeout(success: Option[String]): Action[AnyContent] = Action.async { implicit request =>
     val successUrl = success.getOrElse(routes.ClientInvitationJourneyController.submitWarmUp().url)
     val continueUrl = CallOps
       .localFriendlyUrl(env, config)(successUrl, request.host)
@@ -222,7 +222,7 @@ class ClientInvitationJourneyController @Inject()(
           cannot_confirm_identity(title = Some(Messages("technical-issues.header")), html = Some(failed_iv_5xx())))
       case FailedMatching | FailedDirectorCheck | FailedIV | InsufficientEvidence =>
         Forbidden(cannot_confirm_identity())
-      case UserAborted | TimedOut => Redirect(routes.ClientInvitationJourneyController.signedOut(success))
+      case UserAborted | TimedOut => Redirect(routes.ClientInvitationJourneyController.handleIVTimeout(success))
       case LockedOut              => Redirect(routes.ClientInvitationJourneyController.lockedOut)
       case _                      => Forbidden(cannot_confirm_identity())
     }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -139,9 +139,9 @@ GET         /all-responses-failed                                       @uk.gov.
 GET         /some-responses-failed                                      @uk.gov.hmrc.agentinvitationsfrontend.controllers.ClientInvitationJourneyController.showSomeResponsesFailed
 POST        /some-responses-failed                                      @uk.gov.hmrc.agentinvitationsfrontend.controllers.ClientInvitationJourneyController.submitSomeResponsesFailed
 GET         /not-authorised-as-client                                   @uk.gov.hmrc.agentinvitationsfrontend.controllers.ClientInvitationJourneyController.incorrectlyAuthorisedAsAgent
-GET         /cannot-confirm-identity                                    @uk.gov.hmrc.agentinvitationsfrontend.controllers.ClientInvitationJourneyController.showCannotConfirmIdentity(journeyId: Option[String] ?= None)
+GET         /cannot-confirm-identity                                    @uk.gov.hmrc.agentinvitationsfrontend.controllers.ClientInvitationJourneyController.showCannotConfirmIdentity(journeyId: Option[String] ?= None, success: Option[String] ?= None)
 GET         /session-timeout                                            @uk.gov.hmrc.agentinvitationsfrontend.controllers.ClientInvitationJourneyController.showMissingJourneyHistory
-GET         /signed-out                                                 @uk.gov.hmrc.agentinvitationsfrontend.controllers.ClientInvitationJourneyController.signedOut
+GET         /signed-out                                                 @uk.gov.hmrc.agentinvitationsfrontend.controllers.ClientInvitationJourneyController.signedOut(success: Option[String] ?= None)
 GET         /locked-out                                                 @uk.gov.hmrc.agentinvitationsfrontend.controllers.ClientInvitationJourneyController.lockedOut
 
 GET         /trust-not-claimed                                          @uk.gov.hmrc.agentinvitationsfrontend.controllers.ClientInvitationJourneyController.showTrustNotClaimed

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -141,7 +141,7 @@ POST        /some-responses-failed                                      @uk.gov.
 GET         /not-authorised-as-client                                   @uk.gov.hmrc.agentinvitationsfrontend.controllers.ClientInvitationJourneyController.incorrectlyAuthorisedAsAgent
 GET         /cannot-confirm-identity                                    @uk.gov.hmrc.agentinvitationsfrontend.controllers.ClientInvitationJourneyController.showCannotConfirmIdentity(journeyId: Option[String] ?= None, success: Option[String] ?= None)
 GET         /session-timeout                                            @uk.gov.hmrc.agentinvitationsfrontend.controllers.ClientInvitationJourneyController.showMissingJourneyHistory
-GET         /signed-out                                                 @uk.gov.hmrc.agentinvitationsfrontend.controllers.ClientInvitationJourneyController.signedOut(success: Option[String] ?= None)
+GET         /signed-out                                                 @uk.gov.hmrc.agentinvitationsfrontend.controllers.ClientInvitationJourneyController.handleIVTimeout(success: Option[String] ?= None)
 GET         /locked-out                                                 @uk.gov.hmrc.agentinvitationsfrontend.controllers.ClientInvitationJourneyController.lockedOut
 
 GET         /trust-not-claimed                                          @uk.gov.hmrc.agentinvitationsfrontend.controllers.ClientInvitationJourneyController.showTrustNotClaimed

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/AuthBehaviours.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/AuthBehaviours.scala
@@ -50,7 +50,7 @@ trait AuthBehaviours extends AuthStubs {
       val result = await(action(authorisedAsAnyIndividualClient(request, confidenceLevel = 50)))
       val failureUrl: String =
         URLEncoder.encode(
-          routes.ClientInvitationJourneyController.showCannotConfirmIdentity().url,
+          routes.ClientInvitationJourneyController.showCannotConfirmIdentity(success = Some(request.uri)).url,
           StandardCharsets.UTF_8.toString)
 
       status(result) shouldBe 303

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/ClientInvitationJourneyControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/ClientInvitationJourneyControllerISpec.scala
@@ -727,7 +727,7 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
   "GET /cannot-confirm-identity" should {
     "display the cannot confirm identity page with technical issue content when the failure reason is technicalIssue" in {
       givenIVFailureReasonResponse(TechnicalIssue)
-      val result = controller.showCannotConfirmIdentity(Some("valid-uuid"))(FakeRequest())
+      val result = controller.showCannotConfirmIdentity(Some("valid-uuid"), Some("success-url"))(FakeRequest())
       status(result) shouldBe 403
 
       checkHtmlResultWithBodyText(result, htmlEscapedMessage("technical-issues.header"))
@@ -748,7 +748,7 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
         s"IV returns failed reason $reason " when {
           "display the default page" in {
             givenIVFailureReasonResponse(reason)
-            val result = controller.showCannotConfirmIdentity(Some("valid-uuid"))(FakeRequest())
+            val result = controller.showCannotConfirmIdentity(Some("valid-uuid"), Some("success-url"))(FakeRequest())
             status(result) shouldBe 403
             checkHtmlResultWithBodyMsgs(result,"cannot-confirm-identity.header",
               "cannot-confirm-identity.p1", "cannot-confirm-identity.p2")
@@ -757,15 +757,14 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
       }
     }
 
-  Set(Success, TechnicalIssue, FailedMatching, FailedDirectorCheck, FailedIV, InsufficientEvidence, TimedOut, UserAborted, LockedOut)
+  Set(TechnicalIssue, FailedMatching, FailedDirectorCheck, FailedIV, InsufficientEvidence, TimedOut, UserAborted, LockedOut)
     .foreach { reason =>
     s"IV returns failed reason $reason" when {
       "display the signed out page" in {
         givenIVFailureReasonResponse(reason)
-        val result = controller.showCannotConfirmIdentity(Some("valid-uuid"))(FakeRequest())
+        val result = controller.showCannotConfirmIdentity(Some("valid-uuid"), Some("success-url"))(FakeRequest())
         val resultCode = status(result)
         reason match {
-          case Success => resultCode shouldBe 303
           case TechnicalIssue => {
             resultCode shouldBe 403
             checkHtmlResultWithBodyMsgs(result, "technical-issues.header", "technical-issues.p1","technical-issues.p2")


### PR DESCRIPTION
… IV check to route client to correct place