### PR TITLE
Fixes exception encountered when 'service' is not present in session

### DIFF
--- a/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentsRequestTrackingController.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentsRequestTrackingController.scala
@@ -42,6 +42,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
 
 case class TrackResendForm(service: String, clientType: Option[ClientType], expiryDate: String)
 
@@ -165,7 +166,7 @@ class AgentsRequestTrackingController @Inject()(
             request.session.get("agentLink").getOrElse(""),
             request.session.get("clientType").getOrElse(""),
             request.session.get("expiryDate").getOrElse(""),
-            Service.forId(request.session.get("service").getOrElse(throw new RuntimeException("Service not in session"))),
+            request.session.get("service").flatMap(srv => Try(Service.forId(srv)).toOption),
             request.session.get("agencyEmail").getOrElse(""),
             routes.AgentsRequestTrackingController.showTrackRequests(1).url
           )))

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/views/track/ResendLinkPageConfig.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/views/track/ResendLinkPageConfig.scala
@@ -28,7 +28,7 @@ case class ResendLinkPageConfig(
   agentLink: String,
   clientType: String,
   expiryDate: String,
-  service: Service,
+  maybeService: Option[Service],
   agencyEmail: String,
   backLinkUrl: String)(implicit externalUrls: ExternalUrls, messages: Messages) {
 
@@ -45,12 +45,16 @@ case class ResendLinkPageConfig(
   val asaUrl = externalUrls.agentServicesAccountUrl
 
   val step1Instructions: Option[String] = if (clientType == "personal") {
-    if (service == Service.PersonalIncomeRecord) Some(Messages("invitation-sent.step1.personal.paye"))
-    else if (service == Service.Vat) Some(Messages("invitation-sent.step1.personal.vat"))
-    else None
+    maybeService.flatMap(
+      service =>
+        if (service == Service.PersonalIncomeRecord) Some(Messages("invitation-sent.step1.personal.paye"))
+        else if (service == Service.Vat) Some(Messages("invitation-sent.step1.personal.vat"))
+        else None)
   } else if (clientType == "business") {
-    if (service == Service.Vat) Some(Messages("invitation-sent.step1.business.vat"))
-    else if (service == Service.Trust || service == Service.TrustNT) Some(Messages("invitation-sent.step1.business.trust"))
-    else None
+    maybeService.flatMap(
+      service =>
+        if (service == Service.Vat) Some(Messages("invitation-sent.step1.business.vat"))
+        else if (service == Service.Trust || service == Service.TrustNT) Some(Messages("invitation-sent.step1.business.trust"))
+        else None)
   } else None
 }

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentsRequestTrackingControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentsRequestTrackingControllerISpec.scala
@@ -318,9 +318,29 @@ class AgentsRequestTrackingControllerISpec extends BaseISpec with AuthBehaviours
         getResendLink(authorisedAsValidAgent(request.withSession(
           "agentLink" -> "/agent/",
           "clientType" -> "personal",
-        "expiryDate" -> "2017-05-05",
-        "service" -> "HMRC-MTD-IT",
-        "agencyEmail" -> "abc@xyz.com"), arn.value))
+          "expiryDate" -> "2017-05-05",
+          "service" -> "HMRC-MTD-IT",
+          "agencyEmail" -> "abc@xyz.com"), arn.value))
+
+      checkHtmlResultWithBodyMsgs(result,
+        "invitation-sent.link-text",
+        "invitation-sent.select-link",
+        "invitation-sent.client-warning",
+        "invitation-sent.further-help.heading",
+        "invitation-sent.further-help.link-text.sbs",
+        "invitation-sent.further-help.link-text.asa")
+    }
+
+    "return 200 when service is not present in session" in {
+      val service = ""
+
+      val result =
+        getResendLink(authorisedAsValidAgent(request.withSession(
+          "agentLink" -> "/agent/",
+          "clientType" -> "personal",
+          "expiryDate" -> "2017-05-05",
+          "service" -> service,
+          "agencyEmail" -> "abc@xyz.com"), arn.value))
 
       checkHtmlResultWithBodyMsgs(result,
         "invitation-sent.link-text",


### PR DESCRIPTION
During testing of APB-5739, an issue was found when resending authorisation request. This is happening since recently the relevant code was changed from: ` request.session.get("service").getOrElse("") ` to ` Service.forId(request.session.get("service").getOrElse(throw new RuntimeException("Service not in session"))) `.

We can't always expect that `"service"` will be present in user session. This PR is to fix this issue.

Note: The above exists in other places in `AgentsRequestTrackingController`, which may need to be fixed as part of the refactoring. @dg-21-hmrc 