### PR TITLE
Fix hard-coded Mongo connection string in integration tests

### DIFF
--- a/it/uk/gov/hmrc/agentinvitationsfrontend/support/BaseISpec.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/support/BaseISpec.scala
@@ -90,7 +90,7 @@ abstract class BaseISpec
         "features.enable-trust-urn-identifier"                                    -> true,
         "microservice.services.agent-subscription-frontend.external-url"          -> "someSubscriptionExternalUrl",
         "microservice.services.agent-client-management-frontend.external-url"     -> "someAgentClientManagementFrontendExternalUrl",
-        "mongodb.uri"                                                             -> "mongodb://localhost:27017/agent-invitations-frontend?rm.monitorRefreshMS=1000&rm.failover=default"
+        "mongodb.uri"                                                             -> mongoUri
       )
       .configure(extraConfig)
       .overrides(new TestGuiceModule)

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/support/MongoSupport.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/support/MongoSupport.scala
@@ -11,10 +11,6 @@ import scala.language.postfixOps
 trait MongoSupport extends MongoSpecSupport with BeforeAndAfterEach {
   me: Suite =>
 
-  protected def mongoConfiguration =
-    Map(
-      "mongodb.uri" -> "mongodb://localhost:27017/agent-invitations-frontend?rm.monitorRefreshMS=1000&rm.failover=default")
-
   def dropMongoDb()(implicit ec: ExecutionContext = global): Unit =
     Await.result(mongo().drop(), 5 seconds)
 }


### PR DESCRIPTION
Although the `BaseISpec` class has support for constructing suite-specific Mongo connection string URIs, the current AppBuilder configuration doesn't use it in the integration tests. This PR fixes this.