### PR TITLE
 APB-6627 [CS] remove irv allowlist code

### DIFF
--- a/app/uk/gov/hmrc/agentinvitationsfrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/config/AppConfig.scala
@@ -108,5 +108,4 @@ class AppConfig @Inject()(servicesConfig: ServicesConfig) {
 
   val featuresAltItsa: Boolean = servicesConfig.getBoolean("features.enable-alt-itsa")
 
-  val featuresIrvAllowlist: Boolean = servicesConfig.getBoolean("features.enable-irv-allowlist")
 }

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/connectors/PirRelationshipConnector.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/connectors/PirRelationshipConnector.scala
@@ -123,13 +123,4 @@ class PirRelationshipConnector @Inject()(http: HttpClient)(implicit appConfig: A
     }
   }
 
-  def checkIrvAllowed(arn: Arn)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Boolean] = {
-    val url = new URL(baseUrl, s"/agent-fi-relationship/${arn.value}/irv-allowed")
-    http
-      .GET[HttpResponse](url.toString)
-      .map {
-        case HttpResponse(NO_CONTENT, _, _) => true
-        case HttpResponse(NOT_FOUND, _, _)  => false
-      }
-  }
 }

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentsRequestTrackingController.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentsRequestTrackingController.scala
@@ -107,7 +107,6 @@ class AgentsRequestTrackingController @Inject()(
     for {
       trackResultsPage <- trackService.bindInvitationsAndRelationships(
                            agent.arn,
-                           agent.isAllowlisted,
                            appConfig.trackRequestsShowLastDays,
                            pageInfo,
                            client,
@@ -131,7 +130,7 @@ class AgentsRequestTrackingController @Inject()(
     withAuthorisedAsAgent { agent =>
       implicit val now: LocalDate = LocalDate.now()
       trackService
-        .clientNames(agent.arn, agent.isAllowlisted, appConfig.trackRequestsShowLastDays)
+        .clientNames(agent.arn, appConfig.trackRequestsShowLastDays)
         .flatMap { clientNames =>
           FilterTrackRequestsForm
             .form(clientNames)

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/AuthActions.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/AuthActions.scala
@@ -20,7 +20,6 @@ import play.api.mvc.Results._
 import play.api.mvc.{Request, Result}
 import play.api.{Configuration, Environment, Logging}
 import uk.gov.hmrc.agentinvitationsfrontend.config.{AppConfig, ExternalUrls}
-import uk.gov.hmrc.agentinvitationsfrontend.connectors.PirRelationshipConnector
 import uk.gov.hmrc.agentinvitationsfrontend.models.{AuthorisedAgent, AuthorisedClient, Services}
 import uk.gov.hmrc.agentinvitationsfrontend.support.CallOps
 import uk.gov.hmrc.agentinvitationsfrontend.support.CallOps._
@@ -41,7 +40,6 @@ class AuthActionsImpl @Inject()(
   val env: Environment,
   val config: Configuration,
   val authConnector: AuthConnector,
-  val pirRelationshipConnector: PirRelationshipConnector,
   val appConfig: AppConfig,
   val featureFlags: FeatureFlags
 ) extends AuthorisedFunctions with AuthRedirects with Logging {
@@ -71,11 +69,7 @@ class AuthActionsImpl @Inject()(
     authorised(Enrolment("HMRC-AS-AGENT") and AuthProviders(GovernmentGateway))
       .retrieve(authorisedEnrolments) { enrolments =>
         getArn(enrolments) match {
-          case Some(arn) if appConfig.featuresIrvAllowlist =>
-            pirRelationshipConnector.checkIrvAllowed(arn).flatMap { allowed =>
-              body(AuthorisedAgent(arn, allowed))
-            }
-          case Some(arn) => body(AuthorisedAgent(arn, true))
+          case Some(arn) => body(AuthorisedAgent(arn))
           case None =>
             logger.warn("Arn not found for the logged in agent")
             Future successful Forbidden

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/FeatureFlags.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/FeatureFlags.scala
@@ -32,7 +32,7 @@ trait FeatureFlags {
   val showHmrcCgt: Boolean
   val showPlasticPackagingTax: Boolean
 
-  def isServiceEnabled(service: Service, agent: Option[AuthorisedAgent]): Boolean = service match {
+  def isServiceEnabled(service: Service): Boolean = service match {
     case Service.MtdIt                => showHmrcMtdIt
     case Service.PersonalIncomeRecord => showPersonalIncome
     case Service.Vat                  => showHmrcMtdVat
@@ -41,9 +41,9 @@ trait FeatureFlags {
     case Service.Ppt                  => showPlasticPackagingTax
   }
 
-  def enabledServices(agent: Option[AuthorisedAgent]): Set[Service] = Services.supportedServices.toSet.filter(isServiceEnabled(_, agent))
-  def enabledServicesFor(clientType: ClientType, agent: Option[AuthorisedAgent]): Set[Service] =
-    Services.supportedServicesFor(clientType).filter(isServiceEnabled(_, agent))
+  def enabledServices: Set[Service] = Services.supportedServices.toSet.filter(isServiceEnabled)
+  def enabledServicesFor(clientType: ClientType): Set[Service] =
+    Services.supportedServicesFor(clientType).filter(isServiceEnabled)
 }
 
 @Singleton

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/FeatureFlags.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/FeatureFlags.scala
@@ -31,11 +31,10 @@ trait FeatureFlags {
   val showHmrcTrust: Boolean
   val showHmrcCgt: Boolean
   val showPlasticPackagingTax: Boolean
-  val enableIrvAllowlist: Boolean
 
   def isServiceEnabled(service: Service, agent: Option[AuthorisedAgent]): Boolean = service match {
     case Service.MtdIt                => showHmrcMtdIt
-    case Service.PersonalIncomeRecord => showPersonalIncome && !(enableIrvAllowlist && agent.exists(!_.isAllowlisted))
+    case Service.PersonalIncomeRecord => showPersonalIncome
     case Service.Vat                  => showHmrcMtdVat
     case Service.Trust                => showHmrcTrust
     case Service.CapitalGains         => showHmrcCgt
@@ -56,6 +55,5 @@ case class ConfigFeatureFlags @Inject()(appConfig: AppConfig) extends FeatureFla
   val showHmrcTrust = appConfig.featuresTrust
   val showHmrcCgt = appConfig.featuresCgt
   val showPlasticPackagingTax = appConfig.featuresPlasticPackagingTax
-  val enableIrvAllowlist = appConfig.featuresIrvAllowlist
 
 }

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/journeys/AgentInvitationJourneyModel.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/journeys/AgentInvitationJourneyModel.scala
@@ -142,7 +142,7 @@ object AgentInvitationJourneyModel extends JourneyModel with Logging {
     def selectedClientType(agent: AuthorisedAgent)(clientTypeStr: String): Transition = Transition {
       case SelectClientType(basket) =>
         val clientType = ClientType.toEnum(clientTypeStr)
-        val services = Services.supportedServicesFor(clientType).filter(featureFlags.isServiceEnabled(_, Some(agent)))
+        val services = Services.supportedServicesFor(clientType).filter(featureFlags.isServiceEnabled)
         goto(SelectService(clientType, services, basket))
     }
 
@@ -169,7 +169,7 @@ object AgentInvitationJourneyModel extends JourneyModel with Logging {
               else goto(ReviewAuthorisations(clientType, services, basket)) // otherwise proceed to review
             case Some(service) if services.contains(service) =>
               gotoIdentify(
-                featureFlags.isServiceEnabled(service, Some(agent)),
+                featureFlags.isServiceEnabled(service),
                 service,
                 IdentifyClient(clientType, service, basket),
                 AgentSuspended(service, basket)
@@ -592,7 +592,7 @@ object AgentInvitationJourneyModel extends JourneyModel with Logging {
     def confirmDeleteAuthorisationRequest(agent: AuthorisedAgent)(confirmation: Confirmation) =
       Transition {
         case DeleteAuthorisationRequest(clientType, authorisationRequest, basket) =>
-          val availableServices = Services.supportedServicesFor(clientType).filter(featureFlags.isServiceEnabled(_, Some(agent)))
+          val availableServices = Services.supportedServicesFor(clientType).filter(featureFlags.isServiceEnabled)
           if (confirmation.choice) {
             if ((basket - authorisationRequest).nonEmpty)
               goto(ReviewAuthorisations(clientType, availableServices, basket - authorisationRequest))

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/journeys/AgentLedDeauthJourneyModel.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/journeys/AgentLedDeauthJourneyModel.scala
@@ -101,7 +101,7 @@ object AgentLedDeauthJourneyModel extends JourneyModel with Logging {
     def selectedClientType(agent: AuthorisedAgent)(clientTypeStr: String) = Transition {
       case SelectClientType =>
         val clientType = ClientType.toEnum(clientTypeStr)
-        val availableServices = featureFlags.enabledServicesFor(clientType, Some(agent))
+        val availableServices = featureFlags.enabledServicesFor(clientType)
         goto(SelectService(clientType, availableServices))
     }
 
@@ -113,7 +113,7 @@ object AgentLedDeauthJourneyModel extends JourneyModel with Logging {
         case SelectService(clientType, _) =>
           mService match {
             case Some(service) =>
-              if (featureFlags.isServiceEnabled(service, Some(agent)))
+              if (featureFlags.isServiceEnabled(service))
                 goto(IdentifyClient(clientType, service))
               else fail(new Exception(s"Service: ${service.id} is not enabled"))
             case _ => goto(root)

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/models/AuthorisedAgent.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/models/AuthorisedAgent.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.agentinvitationsfrontend.models
 import play.api.libs.json.Json
 import uk.gov.hmrc.agentmtdidentifiers.model.Arn
 
-case class AuthorisedAgent(arn: Arn, isAllowlisted: Boolean)
+case class AuthorisedAgent(arn: Arn)
 
 object AuthorisedAgent {
   implicit val format = Json.format[AuthorisedAgent]

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/models/InvitationsBasket.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/models/InvitationsBasket.scala
@@ -36,7 +36,7 @@ case class InvitationsBasket(clientType: ClientType, services: Set[Service], bas
       .map(service => service -> Messages(s"select-service.${service.id}.${clientType.toString}"))
 
   def showService(service: Service): Boolean =
-    featureFlags.isServiceEnabled(service, None) && serviceAvailableForSelection(service)
+    featureFlags.isServiceEnabled(service) && serviceAvailableForSelection(service)
 
   protected def serviceAvailableForSelection(service: Service): Boolean =
     if (service == Service.Trust) {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -212,8 +212,6 @@ features {
   enable-welsh-toggle = true
 
   enable-alt-itsa = true
-
-  enable-irv-allowlist = true
 }
 
 # We don't need CSRF check here because the form is NOT submitted from the browser

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/connectors/AuthActionsISpec.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/connectors/AuthActionsISpec.scala
@@ -8,7 +8,6 @@ import play.api.{Configuration, Environment}
 import uk.gov.hmrc.agentinvitationsfrontend.config.ExternalUrls
 import uk.gov.hmrc.agentinvitationsfrontend.controllers.{AuthActionsImpl, FeatureFlags}
 import uk.gov.hmrc.agentinvitationsfrontend.support.BaseISpec
-import uk.gov.hmrc.agentmtdidentifiers.model.Arn
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.http.{HeaderCarrier, SessionKeys}
 import uk.gov.hmrc.play.http.HeaderCarrierConverter

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/connectors/AuthActionsIrvAllowlistISpec.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/connectors/AuthActionsIrvAllowlistISpec.scala
@@ -14,14 +14,13 @@ import uk.gov.hmrc.play.http.HeaderCarrierConverter
 import scala.concurrent.{ExecutionContext, Future}
 
 class AuthActionsIrvAllowlistISpec extends BaseISpec with Injecting {
-  override def extraConfig = Map("features.enable-irv-allowlist" -> true)
 
   val authActions = inject[AuthActionsImpl]
 
   implicit def hc(implicit request: Request[_]): HeaderCarrier =  HeaderCarrierConverter.fromRequestAndSession(request, request.session)
 
-  "withAuthorisedAsAgent" when {
-    "irv-allowlist is enabled" should {
+  "withAuthorisedAsAgent" should {
+
       "redirect to sign in when the user does not have an active session" in {
         givenUnauthorisedWith("MissingBearerToken")
 
@@ -55,7 +54,7 @@ class AuthActionsIrvAllowlistISpec extends BaseISpec with Injecting {
         status(result) shouldBe FORBIDDEN
       }
 
-      "invoke the callback body with the ARN and isAllowed equal to true when the user is on the IRV allowlist" in {
+      "invoke the callback body with the ARN" in {
         val authorise = Json.arr(
           Json.obj("enrolment"     -> "HMRC-AS-AGENT", "identifiers" -> Json.arr(), "state" -> "Activated"),
           Json.obj("authProviders" -> Json.arr("GovernmentGateway"))
@@ -73,53 +72,18 @@ class AuthActionsIrvAllowlistISpec extends BaseISpec with Injecting {
           Json.obj("authorise" -> authorise, "retrieve" -> Json.arr("authorisedEnrolments")).toString(),
           retrieved.toString())
 
-        givenArnIsAllowlistedForIrv(Arn("TARN0000001"))
-
         implicit val request: Request[_] = FakeRequest().withSession(
           SessionKeys.authToken -> "Bearer XYZ")
 
         val result =
           authActions.withAuthorisedAsAgent { agent =>
-            Future.successful(Ok((agent.arn.value, agent.isAllowlisted).toString))
+            Future.successful(Ok(agent.arn.value))
           }(request, hc, ExecutionContext.global)
 
         status(result) shouldBe OK
         // `bodyOf(result)` results in some kind of implicit conversion shenanigans
-        bodyOf(await(result)) shouldBe "(TARN0000001,true)"
+        bodyOf(await(result)) shouldBe "TARN0000001"
       }
 
-      "invoke the callback body with the ARN and isAllowed equal to false when the user is not on the IRV allowlist" in {
-        val authorise = Json.arr(
-          Json.obj("enrolment"     -> "HMRC-AS-AGENT", "identifiers" -> Json.arr(), "state" -> "Activated"),
-          Json.obj("authProviders" -> Json.arr("GovernmentGateway"))
-        )
-        val retrieved = Json.obj(
-          "authorisedEnrolments" -> Json.arr(
-            Json.obj(
-              "key" -> "HMRC-AS-AGENT",
-              "identifiers" -> Json.arr(
-                Json.obj("key" -> "AgentReferenceNumber", "value" -> "TARN0000001")
-              )
-            )
-          ))
-        givenAuthorisedFor(
-          Json.obj("authorise" -> authorise, "retrieve" -> Json.arr("authorisedEnrolments")).toString(),
-          retrieved.toString())
-
-        givenArnIsNotAllowlistedForIrv(Arn("TARN0000001"))
-
-        implicit val request: Request[_] = FakeRequest().withSession(
-          SessionKeys.authToken -> "Bearer XYZ")
-
-        val result =
-          authActions.withAuthorisedAsAgent { agent =>
-            Future.successful(Ok((agent.arn.value, agent.isAllowlisted).toString()))
-          }(request, hc, ExecutionContext.global)
-
-        status(result) shouldBe OK
-        // `bodyOf(result)` results in some kind of implicit conversion shenanigans
-        bodyOf(await(result)) shouldBe "(TARN0000001,false)"
-      }
-    }
   }
 }

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/connectors/AuthActionsIrvAllowlistISpec.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/connectors/AuthActionsIrvAllowlistISpec.scala
@@ -7,7 +7,6 @@ import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}
 import uk.gov.hmrc.agentinvitationsfrontend.controllers.AuthActionsImpl
 import uk.gov.hmrc.agentinvitationsfrontend.support.BaseISpec
-import uk.gov.hmrc.agentmtdidentifiers.model.Arn
 import uk.gov.hmrc.http.{HeaderCarrier, SessionKeys}
 import uk.gov.hmrc.play.http.HeaderCarrierConverter
 

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/connectors/PirRelationshipsConnectorISpec.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/connectors/PirRelationshipsConnectorISpec.scala
@@ -4,7 +4,7 @@ import java.time.LocalDate
 import play.api.test.Helpers._
 import uk.gov.hmrc.agentinvitationsfrontend.stubs.ACRStubs
 import uk.gov.hmrc.agentinvitationsfrontend.support.BaseISpec
-import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, Service}
+import uk.gov.hmrc.agentmtdidentifiers.model.Service
 import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/connectors/PirRelationshipsConnectorISpec.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/connectors/PirRelationshipsConnectorISpec.scala
@@ -33,19 +33,5 @@ class PirRelationshipsConnectorISpec extends BaseISpec with ACRStubs {
       val result = await(connector.getInactiveIrvRelationships)
       result shouldBe Seq.empty
     }
-
-    "checkIrvAllowed" should {
-      "return true when agent-fi-relationship returns 204 No Content" in {
-        val arn = Arn("TARN0000001")
-        givenArnIsAllowlistedForIrv(arn)
-        await(connector.checkIrvAllowed(arn)) shouldBe true
-      }
-
-      "return false when agent-fi-relationship returns 404 Not Found" in {
-        val arn = Arn("TARN0000001")
-        givenArnIsNotAllowlistedForIrv(arn)
-        await(connector.checkIrvAllowed(arn)) shouldBe false
-      }
-    }
   }
 }

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/services/TrackServiceISpec.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/services/TrackServiceISpec.scala
@@ -139,7 +139,7 @@ class TrackServiceISpec extends BaseISpec {
       givenInactiveAfiRelationshipNotFound
       givenASingleInactiveRelationship(Service.Vat, "123456789", LocalDate.now().minusDays(20).toString, LocalDate.now().minusDays(4).toString)
 
-      val result: Seq[TrackInformationSorted] = await(service.allResults(Arn("TARN0000001"), true, 30))
+      val result: Seq[TrackInformationSorted] = await(service.allResults(Arn("TARN0000001"), 30))
 
       result.size shouldBe 1
 
@@ -162,7 +162,7 @@ class TrackServiceISpec extends BaseISpec {
       givenInactiveAfiRelationshipNotFound
       givenASingleInactiveRelationship(Service.Vat, "123456789", LocalDate.now().minusDays(15).toString, LocalDate.now().minusDays(5).toString)
 
-      val result: Seq[TrackInformationSorted] = await(service.allResults(Arn("TARN0000001"), true, 30))
+      val result: Seq[TrackInformationSorted] = await(service.allResults(Arn("TARN0000001"), 30))
 
       result.size shouldBe 2
 
@@ -178,7 +178,7 @@ class TrackServiceISpec extends BaseISpec {
       givenInactiveAfiRelationshipNotFound
       givenASingleInactiveRelationship(Service.Vat, "123456789", LocalDate.now().minusDays(15).toString, LocalDate.now().minusDays(5).toString)
 
-      val result: Seq[TrackInformationSorted] = await(service.allResults(Arn("TARN0000001"), true, 30))
+      val result: Seq[TrackInformationSorted] = await(service.allResults(Arn("TARN0000001"), 30))
 
       result.size shouldBe 2
 
@@ -194,7 +194,7 @@ class TrackServiceISpec extends BaseISpec {
       givenInactiveAfiRelationshipNotFound
       givenASingleInactiveRelationship(Service.Vat, "123456789", LocalDate.now().minusDays(10).toString, LocalDate.now().minusDays(3).toString)
 
-      val result: Seq[TrackInformationSorted] = await(service.allResults(Arn("TARN0000001"), true, 30))
+      val result: Seq[TrackInformationSorted] = await(service.allResults(Arn("TARN0000001"), 30))
 
       result.size shouldBe 1
 
@@ -210,7 +210,7 @@ class TrackServiceISpec extends BaseISpec {
       givenGetInvitations() // 9 invitations
       givenNinoForMtdItId(mtdItId, validNino)
 
-      val result: Seq[TrackInformationSorted] = await(service.allResults(Arn("TARN0000001"), true, 30))
+      val result: Seq[TrackInformationSorted] = await(service.allResults(Arn("TARN0000001"),30))
 
       result.size shouldBe 10
 

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/stubs/AfiRelationshipStub.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/stubs/AfiRelationshipStub.scala
@@ -185,9 +185,4 @@ trait AfiRelationshipStub {
         .willReturn(aResponse()
           .withStatus(404)))
 
-  def givenArnIsAllowlistedForIrv(arn: Arn) =
-    stubFor(get(s"/agent-fi-relationship/${arn.value}/irv-allowed").willReturn(noContent()))
-
-  def givenArnIsNotAllowlistedForIrv(arn: Arn) =
-    stubFor(get(s"/agent-fi-relationship/${arn.value}/irv-allowed").willReturn(notFound()))
 }

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/stubs/AuthStubs.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/stubs/AuthStubs.scala
@@ -12,7 +12,6 @@ trait AuthStubs extends AfiRelationshipStub {
   case class Enrolment(serviceName: String, identifierName: String, identifierValue: String)
 
   def authorisedAsValidAgent[A](request: FakeRequest[A], arn: String)(implicit hc: HeaderCarrier): FakeRequest[A] = {
-    givenArnIsAllowlistedForIrv(Arn(arn))
     authenticatedAgent(request, Enrolment("HMRC-AS-AGENT", "AgentReferenceNumber", arn))
   }
 

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/stubs/AuthStubs.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/stubs/AuthStubs.scala
@@ -3,7 +3,7 @@ package uk.gov.hmrc.agentinvitationsfrontend.stubs
 import com.github.tomakehurst.wiremock.client.WireMock._
 import play.api.test.FakeRequest
 import uk.gov.hmrc.agentinvitationsfrontend.support.WireMockSupport
-import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, TrustTaxIdentifier, Urn, Utr}
+import uk.gov.hmrc.agentmtdidentifiers.model.{TrustTaxIdentifier, Urn, Utr}
 import uk.gov.hmrc.http.{HeaderCarrier, SessionKeys}
 
 trait AuthStubs extends AfiRelationshipStub {

--- a/test/journeys/AgentInvitationFastTrackJourneyModelSpec.scala
+++ b/test/journeys/AgentInvitationFastTrackJourneyModelSpec.scala
@@ -47,7 +47,7 @@ class AgentInvitationFastTrackJourneyModelSpec extends UnitSpec with StateMatche
       await(super.apply(transition))
   }
 
-  val authorisedAgent = AuthorisedAgent(Arn("TARN0000001"), isAllowlisted = true)
+  val authorisedAgent = AuthorisedAgent(Arn("TARN0000001"))
   val availableServices: Set[Service] = Set(Service.PersonalIncomeRecord, Service.MtdIt, Service.Vat, Service.Ppt)
   val nino = Nino("AB123456A")
   val postCode = Some("BN114AW")

--- a/test/journeys/AgentInvitationJourneyModelSpec.scala
+++ b/test/journeys/AgentInvitationJourneyModelSpec.scala
@@ -49,8 +49,7 @@ class AgentInvitationJourneyModelSpec extends UnitSpec with StateMatchers[State]
   }
 
   val emptyBasket: Basket = Set.empty
-  val authorisedAgent = AuthorisedAgent(Arn("TARN0000001"), isAllowlisted = true)
-  val authorisedAgentNotAllowlisted = AuthorisedAgent(Arn("TARN0000001"), isAllowlisted = false)
+  val authorisedAgent = AuthorisedAgent(Arn("TARN0000001"))
   private val availableServices: Set[Service] = Set(Service.PersonalIncomeRecord, Service.MtdIt, Service.Vat, Service.CapitalGains, Service.Ppt)
   private val availableBusinessServices: Set[Service] = Set(Service.Vat, Service.Ppt)
   private val availableTrustServices: Set[Service] = Set(Service.Trust, Service.CapitalGains, Service.Ppt)
@@ -174,21 +173,12 @@ class AgentInvitationJourneyModelSpec extends UnitSpec with StateMatchers[State]
           thenGo(SelectService(Personal, availableServices, emptyBasket))
       }
 
-      "transition to SelectPersonalService with all services when agent is allowlisted" in {
+      "transition to SelectPersonalService with all services with authorised agent" in {
 
         given(SelectClientType(emptyBasket)) when
           transitions.selectedClientType(authorisedAgent)("personal") should
           thenMatch {
             case SelectService(ClientType.Personal, services, _) if services.contains(Service.PersonalIncomeRecord) =>
-          }
-      }
-
-      "transition to SelectPersonalService with fewer services when agent is not allowlisted" in {
-
-        given(SelectClientType(emptyBasket)) when
-          transitions.selectedClientType(authorisedAgentNotAllowlisted)("personal") should
-          thenMatch {
-            case SelectService(ClientType.Personal, services, _) if !services.contains(Service.PersonalIncomeRecord) =>
           }
       }
 

--- a/test/journeys/AgentLedDeauthJourneyModelSpec.scala
+++ b/test/journeys/AgentLedDeauthJourneyModelSpec.scala
@@ -44,8 +44,7 @@ class AgentLedDeauthJourneyModelSpec extends UnitSpec with StateMatchers[State] 
       await(super.apply(transition))
   }
 
-  val authorisedAgent: AuthorisedAgent = AuthorisedAgent(Arn("TARN0000001"), isAllowlisted = true)
-  val nonAllowlistedAgent: AuthorisedAgent = AuthorisedAgent(Arn("TARN0000001"), isAllowlisted = false)
+  val authorisedAgent: AuthorisedAgent = AuthorisedAgent(Arn("TARN0000001"))
   val postCode = "BN114AW"
   val vrn = "123456"
   val nino = "AB123456A"
@@ -130,16 +129,6 @@ class AgentLedDeauthJourneyModelSpec extends UnitSpec with StateMatchers[State] 
         s"transition to SelectService ($clientType) when $clientType is selected" in {
           given(SelectClientType) when transitions.selectedClientType(authorisedAgent)(ClientType.fromEnum(clientType)) should thenGo(
             SelectService(clientType, Services.supportedServicesFor(clientType)))
-        }
-      }
-      "transition to SelectService Personal with IRV-allowlisted agent" in {
-        given(SelectClientType) when transitions.selectedClientType(authorisedAgent)("personal") should thenMatch {
-          case SelectService(ClientType.Personal, services) if services.contains(Service.PersonalIncomeRecord) =>
-        }
-      }
-      "transition to SelectService Personal with non-IRV-allowlisted agent (IRV should not be available)" in {
-        given(SelectClientType) when transitions.selectedClientType(nonAllowlistedAgent)("personal") should thenMatch {
-          case SelectService(ClientType.Personal, services) if !services.contains(Service.PersonalIncomeRecord) =>
         }
       }
     }

--- a/test/services/RequestsTrackingServiceSpec.scala
+++ b/test/services/RequestsTrackingServiceSpec.scala
@@ -192,25 +192,11 @@ class RequestsTrackingServiceSpec extends UnitSpec {
 
       }
 
-      "filter out PIR service if user not allowlisted" in {
-        tested.allowlistedInvitation(false)(invitationForService(Service.PersonalIncomeRecord)) shouldBe false
-
-        tested.allowlistedInvitation(false)(invitationForService(Service.MtdIt)) shouldBe true
-
-        tested.allowlistedInvitation(false)(invitationForService(Service.Vat)) shouldBe true
-
-        tested.allowlistedInvitation(true)(invitationForService(Service.PersonalIncomeRecord)) shouldBe true
-
-        tested.allowlistedInvitation(true)(invitationForService(Service.MtdIt)) shouldBe true
-
-        tested.allowlistedInvitation(true)(invitationForService(Service.Vat)) shouldBe true
-      }
-
       "return empty tracked invitations when none supplied" in {
         when(acaConnector.getAllInvitations(any(classOf[Arn]), any(classOf[LocalDate]))(any(classOf[HeaderCarrier]), any(classOf[ExecutionContext])))
           .thenReturn(Future.successful(Seq()))
 
-        val result = await(tested.getRecentAgentInvitations(Arn(""), isPirAllowlisted = true, 30))
+        val result = await(tested.getRecentAgentInvitations(Arn(""), 30))
 
         result shouldBe empty
       }
@@ -234,7 +220,7 @@ class RequestsTrackingServiceSpec extends UnitSpec {
                 invitationForService(Service.PersonalIncomeRecord)
               )))
 
-        val result = await(tested.getRecentAgentInvitations(Arn(""), isPirAllowlisted = true, 30))
+        val result = await(tested.getRecentAgentInvitations(Arn(""), 30))
 
         // result.map(_.clientName) should contain theSameElementsAs Seq("Aaa Itsa Trader", "Aaa Ltd.", "Foo Bar")
 

--- a/test/services/TrackServiceSpecWithFilter.scala
+++ b/test/services/TrackServiceSpecWithFilter.scala
@@ -41,15 +41,8 @@ class TrackServiceSpecWithFilter extends UnitSpec with TrackServiceStubsAndData 
       )
       givenGetAllInvitations()
 
-      val result = await(
-        tested
-          .bindInvitationsAndRelationships(
-            arn = Arn(""),
-            showLastDays = 30,
-            pageInfo = PageInfo(1, 10),
-            filterByClient = None,
-            filterByStatus = None,
-            isPirAllowlisted = true))
+      val result = await(tested
+        .bindInvitationsAndRelationships(arn = Arn(""), showLastDays = 30, pageInfo = PageInfo(1, 10), filterByClient = None, filterByStatus = None))
 
       result shouldBe tested.TrackResultsPage(
         results = Seq(
@@ -217,8 +210,8 @@ class TrackServiceSpecWithFilter extends UnitSpec with TrackServiceStubsAndData 
           showLastDays = 30,
           pageInfo = PageInfo(1, 10),
           filterByClient = Some("John Jones"),
-          filterByStatus = None,
-          isPirAllowlisted = true))
+          filterByStatus = None)
+      )
 
       result shouldBe tested.TrackResultsPage(
         results = Seq(
@@ -280,9 +273,9 @@ class TrackServiceSpecWithFilter extends UnitSpec with TrackServiceStubsAndData 
           showLastDays = 30,
           pageInfo = PageInfo(1, 10),
           filterByClient = None,
-          filterByStatus = Some(FilterFormStatus.ClientNotYetResponded),
-          isPirAllowlisted = true
-        ))
+          filterByStatus = Some(FilterFormStatus.ClientNotYetResponded)
+        )
+      )
 
       result shouldBe tested.TrackResultsPage(
         results = Seq(
@@ -343,8 +336,7 @@ class TrackServiceSpecWithFilter extends UnitSpec with TrackServiceStubsAndData 
           showLastDays = 30,
           pageInfo = PageInfo(1, 10),
           filterByClient = None,
-          filterByStatus = None,
-          isPirAllowlisted = true
+          filterByStatus = None
         ))
 
       result shouldBe tested.TrackResultsPage(

--- a/test/support/TestFeatureFlags.scala
+++ b/test/support/TestFeatureFlags.scala
@@ -26,7 +26,6 @@ case class TestFeatureFlags(
   override val showHmrcTrust: Boolean = false,
   override val showHmrcCgt: Boolean = false,
   override val showPlasticPackagingTax: Boolean = false,
-  override val enableIrvAllowlist: Boolean = false,
 ) extends FeatureFlags {
   def setServiceFlag(service: Service, flag: Boolean): TestFeatureFlags = service match {
     case Service.MtdIt                   => this.copy(showHmrcMtdIt = flag)
@@ -49,7 +48,6 @@ object TestFeatureFlags {
       showHmrcMtdVat = true,
       showHmrcTrust = true,
       showHmrcCgt = true,
-      showPlasticPackagingTax = true,
-      enableIrvAllowlist = true
+      showPlasticPackagingTax = true
     )
 }


### PR DESCRIPTION
no longer called due to features.enable-irv-allowlist being false in prod since last year

all agents should be able to interact with PersonalIncomeRecord (income record viewer service)