### PR TITLE
Reduce the use of unhelpful 'serviceMessageKey'

### DIFF
--- a/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentInvitationFastTrackJourneyController.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/AgentInvitationFastTrackJourneyController.scala
@@ -432,7 +432,6 @@ class AgentInvitationFastTrackJourneyController @Inject()(
             formWithErrors.or(getKnownFactFormForService(ftr.service)),
             KnownFactPageConfig(
               ftr.service,
-              Services.determineServiceMessageKeyFromService(ftr.service),
               getSubmitKFFor(ftr.service),
               backLinkFor(breadcrumbs).url
             )
@@ -444,7 +443,6 @@ class AgentInvitationFastTrackJourneyController @Inject()(
             formWithErrors.or(getKnownFactFormForService(ftr.service)),
             KnownFactPageConfig(
               ftr.service,
-              Services.determineServiceMessageKeyFromService(ftr.service),
               getSubmitKFFor(ftr.service),
               backLinkFor(breadcrumbs).url
             )
@@ -456,7 +454,6 @@ class AgentInvitationFastTrackJourneyController @Inject()(
             formWithErrors.or(getKnownFactFormForService(ftr.service)),
             KnownFactPageConfig(
               ftr.service,
-              Services.determineServiceMessageKeyFromService(ftr.service),
               getSubmitKFFor(ftr.service),
               backLinkFor(breadcrumbs).url
             )

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/models/ClientConsent.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/models/ClientConsent.scala
@@ -24,13 +24,10 @@ import java.time.LocalDate
 case class ClientConsent(
   invitationId: InvitationId,
   expiryDate: LocalDate,
-  serviceKey: String,
+  service: Service,
   consent: Boolean,
   processed: Boolean = false,
-  isAltItsa: Boolean = false) {
-
-  def service: Service = Services.determineServiceFromServiceMessageKey(this.serviceKey)
-}
+  isAltItsa: Boolean = false)
 
 object ClientConsent {
   implicit val format = Json.format[ClientConsent]

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/services/InvitationsService.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/services/InvitationsService.scala
@@ -167,41 +167,41 @@ class InvitationsService @Inject()(
     hc: HeaderCarrier,
     ec: ExecutionContext) =
     for {
-      result <- Services.determineServiceMessageKey(invitationId) match {
-                 case "itsa" if isAltItsa(si) =>
+      result <- Services.determineService(invitationId) match {
+                 case Service.MtdIt if isAltItsa(si) =>
                    if (response == "Accepted")
                      acaConnector.acceptAltITSAInvitation(Nino(si.clientId), invitationId)
                    else acaConnector.rejectAltITSAInvitation(Nino(si.clientId), invitationId)
 
-                 case "itsa" =>
+                 case Service.MtdIt =>
                    if (response == "Accepted")
                      acaConnector.acceptITSAInvitation(MtdItId(si.clientId), invitationId)
                    else acaConnector.rejectITSAInvitation(MtdItId(si.clientId), invitationId)
 
-                 case "afi" =>
+                 case Service.PersonalIncomeRecord =>
                    if (response == "Accepted") acaConnector.acceptAFIInvitation(Nino(si.clientId), invitationId)
                    else acaConnector.rejectAFIInvitation(Nino(si.clientId), invitationId)
 
-                 case "vat" =>
+                 case Service.Vat =>
                    if (response == "Accepted") acaConnector.acceptVATInvitation(Vrn(si.clientId), invitationId)
                    else acaConnector.rejectVATInvitation(Vrn(si.clientId), invitationId)
 
-                 case "trust" =>
+                 case Service.Trust =>
                    if (response == "Accepted")
                      acaConnector.acceptTrustInvitation(Utr(si.clientId), invitationId)
                    else acaConnector.rejectTrustInvitation(Utr(si.clientId), invitationId)
 
-                 case "trustNT" =>
+                 case Service.TrustNT =>
                    if (response == "Accepted")
                      acaConnector.acceptTrustInvitation(Urn(si.clientId), invitationId)
                    else acaConnector.rejectTrustInvitation(Urn(si.clientId), invitationId)
 
-                 case "cgt" =>
+                 case Service.CapitalGains =>
                    if (response == "Accepted")
                      acaConnector.acceptCgtInvitation(CgtRef(si.clientId), invitationId)
                    else acaConnector.rejectCgtInvitation(CgtRef(si.clientId), invitationId)
 
-                 case "ppt" =>
+                 case Service.Ppt =>
                    if (response == "Accepted")
                      acaConnector.acceptPptInvitation(PptRef(si.clientId), invitationId)
                    else acaConnector.rejectPptInvitation(PptRef(si.clientId), invitationId)

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/views/agents/KnownFactPageConfig.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/views/agents/KnownFactPageConfig.scala
@@ -19,4 +19,4 @@ package uk.gov.hmrc.agentinvitationsfrontend.views.agents
 import play.api.mvc.Call
 import uk.gov.hmrc.agentmtdidentifiers.model.Service
 
-case class KnownFactPageConfig(service: Service, serviceMessageKey: String, submitKFCall: Call, backLinkUrl: String) {}
+case class KnownFactPageConfig(service: Service, submitKFCall: Call, backLinkUrl: String)

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/ConfirmDeclinePageConfig.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/ConfirmDeclinePageConfig.scala
@@ -16,5 +16,6 @@
 
 package uk.gov.hmrc.agentinvitationsfrontend.views.clients
 import play.api.mvc.Call
+import uk.gov.hmrc.agentmtdidentifiers.model.Service
 
-case class ConfirmDeclinePageConfig(agencyName: String, clientType: String, uid: String, serviceKeys: Seq[String], submitUrl: Call, backLink: Call)
+case class ConfirmDeclinePageConfig(agencyName: String, clientType: String, uid: String, services: Seq[Service], submitUrl: Call, backLink: Call)

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/ConfirmTermsPageConfig.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/ConfirmTermsPageConfig.scala
@@ -35,7 +35,7 @@ case class ConfirmTermsPageConfig(
   val serviceKeyAndExpiryDateSeq: Seq[ClientConsent] = {
     consentSeq
       .sortWith(expiryDateDescending)
-      .map(consent => consent.serviceKey -> consent)
+      .map(consent => consent.service -> consent)
       .toMap
       .values
       .toSeq

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/InvitationDeclinedPageConfig.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/InvitationDeclinedPageConfig.scala
@@ -17,5 +17,6 @@
 package uk.gov.hmrc.agentinvitationsfrontend.views.clients
 
 import uk.gov.hmrc.agentinvitationsfrontend.models.ClientType
+import uk.gov.hmrc.agentmtdidentifiers.model.Service
 
-case class InvitationDeclinedPageConfig(agencyName: String, serviceKeys: Seq[String], clientType: ClientType)
+case class InvitationDeclinedPageConfig(agencyName: String, services: Seq[Service], clientType: ClientType)

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/action_needed.scala.html
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/action_needed.scala.html
@@ -27,7 +27,7 @@
     govukDetails: GovukDetails,
 )
 
-@(clientType: ClientType, serviceMessageKey: String)(implicit request: Request[_], msgs: Messages, configuration: Configuration, externalUrls: ExternalUrls, contactFrontendConfig: ContactFrontendConfig)
+@(clientType: ClientType)(implicit request: Request[_], msgs: Messages, configuration: Configuration, externalUrls: ExternalUrls, contactFrontendConfig: ContactFrontendConfig)
 
 @detailsContent = {
     @p(msgs("action-needed.details.p1", msgs("action-needed.vat.link-text")))

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/agent_cancelled_request.scala.html
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/agent_cancelled_request.scala.html
@@ -21,7 +21,7 @@
 
 @this(mainTemplate: MainTemplate,a:a, p:p, h1:h1)
 
-@(serviceMessageKey: String, cancelledOn: String)(implicit request: Request[_], msgs: Messages, configuration: Configuration, externalUrls: ExternalUrls, contactFrontendConfig: ContactFrontendConfig)
+@(cancelledOn: String)(implicit request: Request[_], msgs: Messages, configuration: Configuration, externalUrls: ExternalUrls, contactFrontendConfig: ContactFrontendConfig)
 
 @mainTemplate(bannerTitle = "service.name.clients", isAgent = false,
   title = msgs(s"generic.title", msgs("agent-cancelled-request.header"), msgs("service.name.clients")) ) {

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/already_responded.scala.html
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/already_responded.scala.html
@@ -21,7 +21,7 @@
 
 @this(mainTemplate: MainTemplate, h1: h1, p: p)
 
-@(serviceMessageKey: String, respondedOn: String)(implicit request: Request[_], msgs: Messages, configuration: Configuration, externalUrls: ExternalUrls, contactFrontendConfig: ContactFrontendConfig)
+@(respondedOn: String)(implicit request: Request[_], msgs: Messages, configuration: Configuration, externalUrls: ExternalUrls, contactFrontendConfig: ContactFrontendConfig)
 
 @mainTemplate(
     bannerTitle = "service.name.clients",

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/authorisation_request_error_template.scala.html
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/authorisation_request_error_template.scala.html
@@ -23,7 +23,7 @@
 
 @this(mainTemplate: MainTemplate, h1: h1, p: p, span: span, a: a)
 
-@(serviceMessageKey: String, clientType: String, eventDate: String, errorCase: AuthRequestErrorCase)(implicit request: Request[_], msgs: Messages, configuration: Configuration, externalUrls: ExternalUrls, contactFrontendConfig: ContactFrontendConfig)
+@(clientType: String, eventDate: String, errorCase: AuthRequestErrorCase)(implicit request: Request[_], msgs: Messages, configuration: Configuration, externalUrls: ExternalUrls, contactFrontendConfig: ContactFrontendConfig)
 
 @mainTemplate(
     bannerTitle = "service.name.clients",

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/check_answers.scala.html
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/check_answers.scala.html
@@ -23,6 +23,7 @@
 @import uk.gov.hmrc.govukfrontend.views.html.components.{FormWithCSRF, Text}
 @import uk.gov.hmrc.govukfrontend.views.html.components.implicits._
 @import uk.gov.hmrc.hmrcfrontend.views.html.components.implicits._
+@import uk.gov.hmrc.agentinvitationsfrontend.models.Services.serviceMessageKeys
 
 @this(
     mainTemplate: MainTemplate,
@@ -48,12 +49,12 @@
     <dl class="govuk-summary-list govuk-!-margin-bottom-6">
     @for(consent <- pageConfig.consents) {
         @checkAnswersRow(
-            key = msgs(s"check-answers.service.${consent.serviceKey}"),
-            valueId = s"client-identifier-${consent.serviceKey}",
+            key = msgs(s"check-answers.service.${serviceMessageKeys(consent.service)}"),
+            valueId = s"client-identifier-${serviceMessageKeys(consent.service)}",
             value = msgs(s"check-answers.consent.${consent.consent}"),
             actionText = Some(msgs("check-answers.change-link")) ,
-            actionHref = Some(pageConfig.changeCall(consent.serviceKey).url),
-            hiddenActionText = Some(msgs("check-answers.change-link") + " " + msgs(s"check-answers.service.${consent.serviceKey}"))
+            actionHref = Some(pageConfig.changeCall(serviceMessageKeys(consent.service)).url),
+            hiddenActionText = Some(msgs("check-answers.change-link") + " " + msgs(s"check-answers.service.${serviceMessageKeys(consent.service)}"))
         )
     }
     </dl>

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/complete.scala.html
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/complete.scala.html
@@ -21,6 +21,7 @@
 @import uk.gov.hmrc.agentinvitationsfrontend.views.html._
 @import uk.gov.hmrc.govukfrontend.views.html.components.{GovukPanel, Panel, Text}
 @import views.html.helper.CSPNonce
+@import uk.gov.hmrc.agentinvitationsfrontend.models.Services.serviceMessageKeys
 
 @this(
     mainTemplate: MainTemplate,
@@ -69,12 +70,12 @@ scriptElem = Some(gtmScript)
     ))
 
     @h2("client-complete.p.title")
-    @if(config.consents.filter(_.consent == true).map(_.serviceKey).length == 1) {
-        @p(msgs(s"client-complete.${config.consents.filter(_.consent == true).map(_.serviceKey).head}.p1",
+    @if(config.consents.filter(_.consent == true).length == 1) {
+        @p(msgs(s"client-complete.${config.consents.filter(_.consent == true).map(c => serviceMessageKeys(c.service)).head}.p1",
             config.agencyName))
     } else {
         @p(msgs(s"client-complete.multi.p1.head", config.agencyName))
-        @ul(items = config.consents.filter(_.consent == true).map("client-complete.multi.p1." +  _.serviceKey))
+        @ul(items = config.consents.filter(_.consent == true).map(c => "client-complete.multi.p1." +  serviceMessageKeys(c.service)))
     }
 
     @h2("client-complete.sub-header")

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/confirm_decline.scala.html
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/confirm_decline.scala.html
@@ -25,6 +25,7 @@
 @import uk.gov.hmrc.hmrcfrontend.config.ContactFrontendConfig
 @import uk.gov.hmrc.hmrcfrontend.views.config.HmrcYesNoRadioItems
 @import uk.gov.hmrc.hmrcfrontend.views.html.components.implicits._
+@import uk.gov.hmrc.agentinvitationsfrontend.models.Services.serviceMessageKeys
 
 @this(
     mainTemplate: MainTemplate,
@@ -50,11 +51,11 @@
 
     @formWithCSRF(action = config.submitUrl) {
 
-        @if(config.serviceKeys.length == 1){
+        @if(config.services.length == 1){
             @inputYesNoRadio(
                 field = confirmDeclineForm("accepted"),
                 legend = msgs("confirm-decline.heading"),
-                hint = Some(msgs(s"confirm-decline.${config.serviceKeys.head}.sub-header", config.agencyName)),
+                hint = Some(msgs(s"confirm-decline.${serviceMessageKeys(config.services.head)}.sub-header", config.agencyName)),
                 headingIsLegend = true
             )
         } else {
@@ -63,7 +64,7 @@
                 hint = Some(
                     Hint(content = HtmlContent(
                         p(msgs(s"confirm-decline.sub-header", config.agencyName)) + "" +
-                        ul(items = config.serviceKeys.map(key => s"confirm-decline.$key.service-name"))
+                        ul(items = config.services.map(service => s"confirm-decline.${serviceMessageKeys(service)}.service-name"))
                     ))
                 ),
                 fieldset = Some(Fieldset(

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/confirm_terms_multi.scala.html
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/confirm_terms_multi.scala.html
@@ -24,6 +24,8 @@
 @import uk.gov.hmrc.govukfrontend.views.html.components.{ErrorSummary, FormWithCSRF, GovukErrorSummary}
 @import uk.gov.hmrc.hmrcfrontend.config.ContactFrontendConfig
 @import uk.gov.hmrc.hmrcfrontend.views.html.components.implicits._
+@import uk.gov.hmrc.agentmtdidentifiers.model.Service
+@import uk.gov.hmrc.agentinvitationsfrontend.models.Services.serviceMessageKeys
 
 @this(
     mainTemplate: MainTemplate,
@@ -140,19 +142,19 @@
   }
 }
 
-@suitableTerms(serviceKey: String, expiryDate: String, isAltItsa: Boolean) = {
+@suitableTerms(service: Service, expiryDate: String, isAltItsa: Boolean) = {
     @if(isAltItsa) {
         @p(msgs("confirm-terms-multi.expires.p2", expiryDate))
     }
     @{
-        serviceKey match {
-            case "itsa" => itsaTerms
-            case "afi" => pirTerms
-            case "vat" => vatTerms
-            case "trust" => trustTerms
-            case "trustNT" => trustNTTerms
-            case "cgt" => cgtTerms
-            case "ppt" => pptTerms
+        service match {
+            case Service.MtdIt                => itsaTerms
+            case Service.PersonalIncomeRecord => pirTerms
+            case Service.Vat                  => vatTerms
+            case Service.Trust                => trustTerms
+            case Service.TrustNT              => trustNTTerms
+            case Service.CapitalGains         => cgtTerms
+            case Service.Ppt                  => pptTerms
         }
     }
     @if(!isAltItsa) {
@@ -164,11 +166,11 @@
    if(changingConsent) msgs("change.consent.heading") else msgs("confirm-terms.multi.heading")
 }
 
-@label(serviceKey: String) = @{
-    if(pageConfig.clientType == "business" && serviceKey == "cgt") {
-        msgs(s"confirm-terms-multi.${serviceKey}.business.label", pageConfig.agencyName)
+@label(service: Service) = @{
+    if(pageConfig.clientType == "business" && service == Service.CapitalGains) {
+        msgs(s"confirm-terms-multi.${serviceMessageKeys(service)}.business.label", pageConfig.agencyName)
     } else {
-        msgs(s"confirm-terms-multi.${serviceKey}.label", pageConfig.agencyName)
+        msgs(s"confirm-terms-multi.${serviceMessageKeys(service)}.label", pageConfig.agencyName)
     }
 }
 
@@ -204,28 +206,28 @@
 
             @if(pageConfig.isPending(consent)) {
 
-                @if(List("cgt", "ppt").contains(consent.serviceKey)) {
-                    @h2(key = s"confirm-terms-multi.${consent.serviceKey}.${pageConfig.clientType}.heading",
+                @if(List(Service.CapitalGains, Service.Ppt).contains(consent.service)) {
+                    @h2(key = s"confirm-terms-multi.${serviceMessageKeys(consent.service)}.${pageConfig.clientType}.heading",
                         classes = Some("govuk-!-margin-bottom-4 govuk-!-margin-top-4"))
                 }else{
-                    @h2(key = s"confirm-terms-multi.${consent.serviceKey}.heading",
+                    @h2(key = s"confirm-terms-multi.${serviceMessageKeys(consent.service)}.heading",
                         classes = Some("govuk-!-margin-bottom-4 govuk-!-margin-top-4"))
                 }
 
-                @suitableTerms(consent.serviceKey, displayDateForLang(Some(consent.expiryDate)), consent.isAltItsa)
+                @suitableTerms(consent.service, displayDateForLang(Some(consent.expiryDate)), consent.isAltItsa)
 
                 @if(pageConfig.consentSeq.length == 1 && pageConfig.consentSeq.head.consent) {
                     @inputSingleCheckbox(
-                        field = confirmTermsForm(s"confirmedTerms_${consent.serviceKey}"),
+                        field = confirmTermsForm(s"confirmedTerms_${serviceMessageKeys(consent.service)}"),
                         legend = msgs(s"confirm-terms.legend.${if(pageConfig.isSingleConsent) "single" else "multi"}",pageConfig.agencyName),
-                        checkboxText = label(consent.serviceKey),
+                        checkboxText = label(consent.service),
                         isChecked = true
                     )
                 } else {
                     @inputSingleCheckbox(
-                        field = confirmTermsForm(s"confirmedTerms.${consent.serviceKey}"),
+                        field = confirmTermsForm(s"confirmedTerms.${serviceMessageKeys(consent.service)}"),
                         legend = msgs(s"confirm-terms.legend.${if(pageConfig.isSingleConsent) "single" else "multi"}",pageConfig.agencyName),
-                        checkboxText = label(consent.serviceKey)
+                        checkboxText = label(consent.service)
                     )
                 }
 

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/incorrect_invitation.scala.html
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/incorrect_invitation.scala.html
@@ -22,7 +22,7 @@
 
 @this(mainTemplate: MainTemplate, p:p, a:a, h1:h1)
 
-@(serviceMessageKey: String)(implicit request: Request[_], msgs: Messages, configuration: Configuration, externalUrls: ExternalUrls, contactFrontendConfig: ContactFrontendConfig)
+@()(implicit request: Request[_], msgs: Messages, configuration: Configuration, externalUrls: ExternalUrls, contactFrontendConfig: ContactFrontendConfig)
 
 @mainTemplate(
  bannerTitle = "service.name.clients",

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/invitation_already_responded.scala.html
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/invitation_already_responded.scala.html
@@ -21,7 +21,7 @@
 
 @this(mainTemplate: MainTemplate, p: p, a: a, h1: h1)
 
-@(serviceMessageKey: String)(implicit request: Request[_], msgs: Messages, configuration: Configuration, externalUrls: ExternalUrls, contactFrontendConfig: ContactFrontendConfig)
+@()(implicit request: Request[_], msgs: Messages, configuration: Configuration, externalUrls: ExternalUrls, contactFrontendConfig: ContactFrontendConfig)
 
 @mainTemplate(
     bannerTitle = "service.name.clients",

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/invitation_declined.scala.html
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/invitation_declined.scala.html
@@ -20,6 +20,8 @@
 @import uk.gov.hmrc.agentinvitationsfrontend.views.html._
 @import uk.gov.hmrc.govukfrontend.views.html.components.{GovukPanel, Panel, Text}
 @import uk.gov.hmrc.hmrcfrontend.config.ContactFrontendConfig
+@import uk.gov.hmrc.agentinvitationsfrontend.models.Services.serviceMessageKeys
+@import uk.gov.hmrc.agentmtdidentifiers.model.Service
 
 @this(mainTemplate: MainTemplate, p:p, a:a, h2:h2, ul: ul, govukPanel: GovukPanel)
 
@@ -35,13 +37,13 @@
         title = Text(msgs("invitation-declined.header"))
     ))
 
-    @if(config.serviceKeys.length == 1) {
-        @p(msgs(s"invitation-declined.multi.${config.serviceKeys.head}.p1", config.agencyName))
+    @if(config.services.length == 1) {
+        @p(msgs(s"invitation-declined.multi.${serviceMessageKeys(config.services.head)}.p1", config.agencyName))
     } else {
         @p(msgs(s"invitation-decline.sub-header", config.agencyName))
         @ul(
-            items = config.serviceKeys.map(key => {
-                val k = if(key == "cgt") s"cgt.${config.clientType}" else key
+            items = config.services.map(service => {
+                val k = if(service == Service.CapitalGains) s"${serviceMessageKeys(service)}.${config.clientType}" else serviceMessageKeys(service)
                 s"confirm-decline.$k.service-name"
             })
         )

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/invitation_expired.scala.html
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/invitation_expired.scala.html
@@ -21,7 +21,7 @@
 
 @this(mainTemplate: MainTemplate, p: p, a: a, h1: h1)
 
-@(serviceMessageKey: String)(implicit request: Request[_], msgs: Messages, configuration: Configuration, externalUrls: ExternalUrls, contactFrontendConfig: ContactFrontendConfig)
+@()(implicit request: Request[_], msgs: Messages, configuration: Configuration, externalUrls: ExternalUrls, contactFrontendConfig: ContactFrontendConfig)
 
 @mainTemplate(bannerTitle = "service.name.clients", title = msgs("generic.title", msgs("invitation-expired.heading"), msgs("service.name.clients")), isAgent = false) {
 

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/invitations_responded.scala.html
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/invitations_responded.scala.html
@@ -21,7 +21,7 @@
 
 @this(mainTemplate: MainTemplate, h1: h1)
 
-@(serviceMessageKey: String)(implicit request: Request[_], msgs: Messages, configuration: Configuration, externalUrls: ExternalUrls, contactFrontendConfig: ContactFrontendConfig)
+@()(implicit request: Request[_], msgs: Messages, configuration: Configuration, externalUrls: ExternalUrls, contactFrontendConfig: ContactFrontendConfig)
 
 @mainTemplate(
     bannerTitle = "service.name.clients",

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/no_outstanding_requests.scala.html
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/no_outstanding_requests.scala.html
@@ -21,7 +21,7 @@
 
 @this(mainTemplate: MainTemplate ,a:a, p:p, h1:h1, span:span)
 
-@(serviceMessageKey: String = "afi")(implicit request: Request[_], configuration: Configuration, msgs: Messages, externalUrls: ExternalUrls, contactFrontendConfig: ContactFrontendConfig)
+@()(implicit request: Request[_], configuration: Configuration, msgs: Messages, externalUrls: ExternalUrls, contactFrontendConfig: ContactFrontendConfig)
 
 @mainTemplate(
   bannerTitle = "service.name.clients",  isAgent = false,

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/not_authorised_as_client.scala.html
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/not_authorised_as_client.scala.html
@@ -22,7 +22,7 @@
 
 @this(mainTemplate: MainTemplate, linkStyledAsButton: LinkStyledAsButton, h1: h1, p: p)
 
-@(serviceMessageKey: String = "afi")(implicit request: Request[_], msgs: Messages, configuration: Configuration, externalUrls: ExternalUrls, contactFrontendConfig: ContactFrontendConfig)
+@()(implicit request: Request[_], msgs: Messages, configuration: Configuration, externalUrls: ExternalUrls, contactFrontendConfig: ContactFrontendConfig)
 
 @mainTemplate(
     bannerTitle = "service.name.clients",

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/not_found_invitation.scala.html
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/not_found_invitation.scala.html
@@ -21,7 +21,7 @@
 
 @this(mainTemplate: MainTemplate, h1: h1, p: p)
 
-@(serviceMessageKey: String)(implicit request: Request[_], msgs: Messages, configuration: Configuration, externalUrls: ExternalUrls, contactFrontendConfig: ContactFrontendConfig)
+@()(implicit request: Request[_], msgs: Messages, configuration: Configuration, externalUrls: ExternalUrls, contactFrontendConfig: ContactFrontendConfig)
 
 @mainTemplate(
     bannerTitle = "service.name.clients",

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/request_cancelled.scala.html
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/request_cancelled.scala.html
@@ -21,7 +21,7 @@
 
 @this(mainTemplate: MainTemplate, p: p, a: a, h1: h1)
 
-@(serviceMessageKey: String)(implicit request: Request[_], msgs: Messages, configuration: Configuration, externalUrls: ExternalUrls, contactFrontendConfig: ContactFrontendConfig)
+@()(implicit request: Request[_], msgs: Messages, configuration: Configuration, externalUrls: ExternalUrls, contactFrontendConfig: ContactFrontendConfig)
 
 @mainTemplate(
     bannerTitle = "service.name.clients",

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/request_expired.scala.html
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/request_expired.scala.html
@@ -21,7 +21,7 @@
 
 @this(mainTemplate: MainTemplate, h1: h1, p: p, a: a)
 
-@(serviceMessageKey: String, expiredOn: String)(implicit request: Request[_], msgs: Messages, configuration: Configuration, externalUrls: ExternalUrls, contactFrontendConfig: ContactFrontendConfig)
+@(expiredOn: String)(implicit request: Request[_], msgs: Messages, configuration: Configuration, externalUrls: ExternalUrls, contactFrontendConfig: ContactFrontendConfig)
 
 @mainTemplate(
     bannerTitle = "service.name.clients",

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/some_responses_failed.scala.html
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/views/clients/some_responses_failed.scala.html
@@ -21,6 +21,7 @@
 @import uk.gov.hmrc.agentinvitationsfrontend.views.html.components.SubmitButton
 @import uk.gov.hmrc.govukfrontend.views.html.components.{FormWithCSRF, GovukErrorSummary}
 @import uk.gov.hmrc.hmrcfrontend.config.ContactFrontendConfig
+@import uk.gov.hmrc.agentinvitationsfrontend.models.Services.serviceMessageKeys
 
 @this(
     mainTemplate: MainTemplate,
@@ -40,11 +41,11 @@
 
     @h1("some-responses-failed.header")
 
-    @if(config.consents.map(_.serviceKey).length == 1) {
-        @p(s"some-responses-failed.${config.consents.head.serviceKey}")
+    @if(config.consents.length == 1) {
+        @p(s"some-responses-failed.${serviceMessageKeys(config.consents.head.service)}")
     } else {
         @p("some-responses-failed.p1")
-        @ul(items = config.consents.map(s"some-responses-failed.li." + _.serviceKey))
+        @ul(items = config.consents.map(consent => s"some-responses-failed.li." + serviceMessageKeys(consent.service)))
     }
 
     @p("some-responses-failed.try-again")

--- a/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/ClientInvitationJourneyControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentinvitationsfrontend/controllers/ClientInvitationJourneyControllerISpec.scala
@@ -672,7 +672,7 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
           uid,
           "My Agency",
           arn,
-          Seq(ClientConsent(invitationIdITSA, LocalDate.now().plusDays(1), "itsa", consent = true, isAltItsa = true))),
+          Seq(ClientConsent(invitationIdITSA, LocalDate.now().plusDays(1), Service.MtdIt, consent = true, isAltItsa = true))),
         Nil)
 
       val result = controller.showConsent(authorisedAsIndividualClientWithSomeSupportedEnrolments(request))
@@ -705,7 +705,7 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
           uid,
           "My Agency",
           arn,
-          Seq(ClientConsent(invitationIdITSA, LocalDate.now().plusDays(1), "itsa", consent = true))),
+          Seq(ClientConsent(invitationIdITSA, LocalDate.now().plusDays(1), Service.MtdIt, consent = true))),
         Nil)
 
       val result = controller.showConsent(authorisedAsIndividualClientWithSomeSupportedEnrolments(request))
@@ -738,7 +738,7 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
           uid,
           "My Agency",
           arn,
-          Seq(ClientConsent(invitationIdCgt, LocalDate.now().plusDays(1), "cgt", consent = true))),
+          Seq(ClientConsent(invitationIdCgt, LocalDate.now().plusDays(1), Service.CapitalGains, consent = true))),
         Nil)
 
       val result = controller.showConsent(authorisedAsIndividualClientWithSomeSupportedEnrolments(request))
@@ -770,8 +770,8 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
           uid,
           "My Agency",
           arn,
-          Seq(ClientConsent(invitationIdCgt, LocalDate.now().plusDays(1), "cgt", consent = true),
-            ClientConsent(invitationIdITSA, expiryDate, "itsa", consent = true))),
+          Seq(ClientConsent(invitationIdCgt, LocalDate.now().plusDays(1), Service.CapitalGains, consent = true),
+            ClientConsent(invitationIdITSA, expiryDate, Service.MtdIt, consent = true))),
         Nil)
 
       val result = controller.showConsent(authorisedAsIndividualClientWithSomeSupportedEnrolments(request))
@@ -788,7 +788,7 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
           uid,
           "My Agency",
           arn,
-          Seq(ClientConsent(invitationIdCgt, LocalDate.now().plusDays(1), "cgt", consent = true))),
+          Seq(ClientConsent(invitationIdCgt, LocalDate.now().plusDays(1), Service.CapitalGains, consent = true))),
         Nil)
 
       val result = controller.showConsent(authorisedAsIndividualClientWithSomeSupportedEnrolments(request))
@@ -818,7 +818,7 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
           uid,
           "My Agency",
           arn,
-          Seq(ClientConsent(invitationIdTrust, LocalDate.now().plusDays(1), "trust", consent = true))),
+          Seq(ClientConsent(invitationIdTrust, LocalDate.now().plusDays(1), Service.Trust, consent = true))),
         Nil)
 
       val result = controller.showConsent(authorisedAsOrganisationTrustClient(validUtr)(request))
@@ -838,7 +838,7 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
           uid,
           "My Agency",
           arn,
-          Seq(ClientConsent(invitationIdTrustNT, LocalDate.now().plusDays(1), "trustNT", consent = true))),
+          Seq(ClientConsent(invitationIdTrustNT, LocalDate.now().plusDays(1), Service.TrustNT, consent = true))),
         Nil)
 
       val result = controller.showConsent(authorisedAsOrganisationTrustClient(validUrn)(request))
@@ -864,7 +864,7 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
           uid,
           "My Agency",
           arn,
-          Seq(ClientConsent(invitationIdITSA, expiryDate, "itsa", consent = false))),
+          Seq(ClientConsent(invitationIdITSA, expiryDate, Service.MtdIt, consent = false))),
         Nil)
 
       val result =
@@ -890,12 +890,12 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
           Personal,
           uid,
           "My Agency",
-          ClientConsent(invitationIdITSA, expiryDate, "itsa", consent = true),
+          ClientConsent(invitationIdITSA, expiryDate, Service.MtdIt, consent = true),
           Seq(
-            ClientConsent(invitationIdITSA, expiryDate, "itsa", consent = false),
-            ClientConsent(invitationIdPIR, expiryDate, "afi", consent = false),
-            ClientConsent(invitationIdVAT, expiryDate, "vat", consent = false),
-            ClientConsent(invitationIdCgt, expiryDate, "cgt", consent = false)
+            ClientConsent(invitationIdITSA, expiryDate, Service.MtdIt, consent = false),
+            ClientConsent(invitationIdPIR, expiryDate, Service.PersonalIncomeRecord, consent = false),
+            ClientConsent(invitationIdVAT, expiryDate, Service.Vat, consent = false),
+            ClientConsent(invitationIdCgt, expiryDate, Service.CapitalGains, consent = false)
           )
         ),
         Nil
@@ -909,10 +909,10 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
 
     "display the individual consent page when coming back to it from the CheckAnswers page" in {
       val consents = Seq(
-        ClientConsent(invitationIdITSA, expiryDate, "itsa", consent = false),
-        ClientConsent(invitationIdPIR, expiryDate, "afi", consent = false),
-        ClientConsent(invitationIdVAT, expiryDate, "vat", consent = false),
-        ClientConsent(invitationIdCgt, expiryDate, "cgt", consent = false)
+        ClientConsent(invitationIdITSA, expiryDate, Service.MtdIt, consent = false),
+        ClientConsent(invitationIdPIR, expiryDate, Service.PersonalIncomeRecord, consent = false),
+        ClientConsent(invitationIdVAT, expiryDate, Service.Vat, consent = false),
+        ClientConsent(invitationIdCgt, expiryDate, Service.CapitalGains, consent = false)
       )
       val currentState = CheckAnswers(
         Personal,
@@ -929,7 +929,7 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
             Personal,
             uid,
             "My Agency",
-            ClientConsent(invitationIdITSA, expiryDate, "itsa", consent = true),
+            ClientConsent(invitationIdITSA, expiryDate, Service.MtdIt, consent = true),
             consents
           )
         )
@@ -954,8 +954,8 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
           "uid",
           "My Agency",
           Seq(
-            ClientConsent(invitationIdITSA, expiryDate, "itsa", consent = false),
-            ClientConsent(invitationIdCgt, expiryDate, "cgt", consent = false)
+            ClientConsent(invitationIdITSA, expiryDate, Service.MtdIt, consent = false),
+            ClientConsent(invitationIdCgt, expiryDate, Service.CapitalGains, consent = false)
           )
         ),
         Nil
@@ -990,10 +990,10 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
           uid,
           "My Agency",
           Seq(
-            ClientConsent(invitationIdITSA, expiryDate, "itsa", consent = true),
-            ClientConsent(invitationIdPIR, expiryDate, "afi", consent = true),
-            ClientConsent(invitationIdVAT, expiryDate, "vat", consent = true),
-            ClientConsent(invitationIdCgt, expiryDate, "cgt", consent = true)
+            ClientConsent(invitationIdITSA, expiryDate, Service.MtdIt, consent = true),
+            ClientConsent(invitationIdPIR, expiryDate, Service.PersonalIncomeRecord, consent = true),
+            ClientConsent(invitationIdVAT, expiryDate, Service.Vat, consent = true),
+            ClientConsent(invitationIdCgt, expiryDate, Service.CapitalGains, consent = true)
           )
         ),
         Nil
@@ -1018,10 +1018,10 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
           uid,
           "My Agency",
           Seq(
-            ClientConsent(invitationIdITSA, expiryDate, "itsa", consent = false),
-            ClientConsent(invitationIdPIR, expiryDate, "afi", consent = false),
-            ClientConsent(invitationIdVAT, expiryDate, "vat", consent = false),
-            ClientConsent(invitationIdCgt, expiryDate, "cgt", consent = false)
+            ClientConsent(invitationIdITSA, expiryDate, Service.MtdIt, consent = false),
+            ClientConsent(invitationIdPIR, expiryDate, Service.PersonalIncomeRecord, consent = false),
+            ClientConsent(invitationIdVAT, expiryDate, Service.Vat, consent = false),
+            ClientConsent(invitationIdCgt, expiryDate, Service.CapitalGains, consent = false)
           )
         ),
         Nil
@@ -1045,9 +1045,9 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
           uid,
           "My Agency",
           Seq(
-            ClientConsent(invitationIdITSA, expiryDate, "itsa", consent = true),
-            ClientConsent(invitationIdPIR, expiryDate, "afi", consent = true),
-            ClientConsent(invitationIdVAT, expiryDate, "vat", consent = true)
+            ClientConsent(invitationIdITSA, expiryDate, Service.MtdIt, consent = true),
+            ClientConsent(invitationIdPIR, expiryDate, Service.PersonalIncomeRecord, consent = true),
+            ClientConsent(invitationIdVAT, expiryDate, Service.Vat, consent = true)
           )
         ),
         Nil
@@ -1070,9 +1070,9 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
           uid,
           "My Agency",
           Seq(
-            ClientConsent(invitationIdITSA, expiryDate, "itsa", consent = true),
-            ClientConsent(invitationIdPIR, expiryDate, "afi", consent = true),
-            ClientConsent(invitationIdVAT, expiryDate, "vat", consent = true)
+            ClientConsent(invitationIdITSA, expiryDate, Service.MtdIt, consent = true),
+            ClientConsent(invitationIdPIR, expiryDate, Service.PersonalIncomeRecord, consent = true),
+            ClientConsent(invitationIdVAT, expiryDate, Service.Vat, consent = true)
           )
         ),
         Nil
@@ -1096,7 +1096,7 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
           "uid",
           "My Agency",
           arn,
-          Seq(ClientConsent(invitationIdITSA, expiryDate, "itsa", consent = false))),
+          Seq(ClientConsent(invitationIdITSA, expiryDate, Service.MtdIt, consent = false))),
         Nil)
 
       val result = controller.showConfirmDecline(authorisedAsIndividualClientWithSomeSupportedEnrolments(request))
@@ -1113,7 +1113,7 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
           "uid",
           "My Agency",
           arn,
-          Seq(ClientConsent(invitationIdCgt, expiryDate, "cgt", consent = false))),
+          Seq(ClientConsent(invitationIdCgt, expiryDate, Service.CapitalGains, consent = false))),
         Nil)
 
       val result = controller.showConfirmDecline(authorisedAsIndividualClientWithSomeSupportedEnrolments(request))
@@ -1131,8 +1131,8 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
           "My Agency",
           arn,
           Seq(
-            ClientConsent(invitationIdITSA, expiryDate, "itsa", consent = false),
-            ClientConsent(invitationIdCgt, expiryDate, "cgt", consent = false))
+            ClientConsent(invitationIdITSA, expiryDate, Service.MtdIt, consent = false),
+            ClientConsent(invitationIdCgt, expiryDate, Service.CapitalGains, consent = false))
         ),
         Nil
       )
@@ -1160,7 +1160,7 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
           "uid",
           "My Agency",
           arn,
-          Seq(ClientConsent(invitationIdITSA, expiryDate, "itsa", consent = false))),
+          Seq(ClientConsent(invitationIdITSA, expiryDate, Service.MtdIt, consent = false))),
         Nil)
 
       val result = controller.submitConfirmDecline(
@@ -1176,7 +1176,7 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
           "uid",
           "My Agency",
           arn,
-          Seq(ClientConsent(invitationIdITSA, expiryDate, "itsa", consent = false))),
+          Seq(ClientConsent(invitationIdITSA, expiryDate, Service.MtdIt, consent = false))),
         Nil)
 
       val result = controller.submitConfirmDecline(
@@ -1195,7 +1195,7 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
           "uid",
           "My Agency",
           arn,
-          Seq(ClientConsent(invitationIdTrust, expiryDate, "trust", consent = false))),
+          Seq(ClientConsent(invitationIdTrust, expiryDate, Service.Trust, consent = false))),
         Nil)
 
       val result = controller.submitConfirmDecline(
@@ -1217,8 +1217,8 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
           "My Agency",
           arn,
           Seq(
-            ClientConsent(invitationIdTrust, expiryDate, "trust", consent = false),
-            ClientConsent(invitationIdVAT, expiryDate, "vat", consent = false))
+            ClientConsent(invitationIdTrust, expiryDate, Service.Trust, consent = false),
+            ClientConsent(invitationIdVAT, expiryDate, Service.Vat, consent = false))
         ),
         Nil
       )
@@ -1241,8 +1241,8 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
           InvitationsAccepted(
             "My Agency",
             Seq(
-              ClientConsent(invitationIdITSA, expiryDate, "itsa", consent = true),
-              ClientConsent(invitationIdCgt, expiryDate, "cgt", consent = true)),
+              ClientConsent(invitationIdITSA, expiryDate, Service.MtdIt, consent = true),
+              ClientConsent(invitationIdCgt, expiryDate, Service.CapitalGains, consent = true)),
             Personal),
           Nil
         )
@@ -1263,7 +1263,7 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
         .set(
           InvitationsAccepted(
             "My Agency",
-            Seq(ClientConsent(invitationIdCgt, expiryDate, "cgt", consent = true)),
+            Seq(ClientConsent(invitationIdCgt, expiryDate, Service.CapitalGains, consent = true)),
             Business),
           Nil)
 
@@ -1284,7 +1284,7 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
         .set(
           InvitationsDeclined(
             "My Agency",
-            Seq(ClientConsent(invitationIdITSA, expiryDate, "itsa", consent = false)),
+            Seq(ClientConsent(invitationIdITSA, expiryDate, Service.MtdIt, consent = false)),
             Personal),
           Nil)
 
@@ -1300,7 +1300,7 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
         .set(
           InvitationsDeclined(
             "My Agency",
-            Seq(ClientConsent(invitationIdCgt, expiryDate, "cgt", consent = false)),
+            Seq(ClientConsent(invitationIdCgt, expiryDate, Service.CapitalGains, consent = false)),
             Personal),
           Nil)
 
@@ -1338,9 +1338,9 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
           SomeResponsesFailed(
             "My Agency",
             Seq(
-              ClientConsent(invitationIdITSA, expiryDate, "itsa", consent = true),
-              ClientConsent(invitationIdCgt, expiryDate, "cgt", consent = true)),
-            Seq(ClientConsent(invitationIdPIR, expiryDate, "afi", consent = true)),
+              ClientConsent(invitationIdITSA, expiryDate, Service.MtdIt, consent = true),
+              ClientConsent(invitationIdCgt, expiryDate, Service.CapitalGains, consent = true)),
+            Seq(ClientConsent(invitationIdPIR, expiryDate, Service.PersonalIncomeRecord, consent = true)),
             Personal
           ),
           Nil
@@ -1364,8 +1364,8 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
         .set(
           SomeResponsesFailed(
             "My Agency",
-            Seq(ClientConsent(invitationIdITSA, expiryDate, "itsa", consent = true)),
-            Seq(ClientConsent(invitationIdPIR, expiryDate, "afi", consent = true)),
+            Seq(ClientConsent(invitationIdITSA, expiryDate, Service.MtdIt, consent = true)),
+            Seq(ClientConsent(invitationIdPIR, expiryDate, Service.PersonalIncomeRecord, consent = true)),
             Personal
           ),
           Nil
@@ -1378,7 +1378,7 @@ class ClientInvitationJourneyControllerISpec extends BaseISpec with StateAndBrea
       journeyState.get.get._1 shouldBe
         InvitationsAccepted(
           "My Agency",
-          Seq(ClientConsent(invitationIdPIR, expiryDate, "afi", consent = true)),
+          Seq(ClientConsent(invitationIdPIR, expiryDate, Service.PersonalIncomeRecord, consent = true)),
           Personal)
     }
   }

--- a/test/journeys/ClientInvitationJourneyModelSpec.scala
+++ b/test/journeys/ClientInvitationJourneyModelSpec.scala
@@ -148,7 +148,7 @@ class ClientInvitationJourneyModelSpec extends UnitSpec with StateMatchers[State
 
           given(WarmUp(Personal, uid, arn, agentName, normalisedAgentName)) when
             submitWarmUp(getInvitationDetails, getNotSuspended)(Some(authorisedIndividualClient)) should
-            thenGo(MultiConsent(Personal, uid, agentName, arn, Seq(ClientConsent(invitationIdItsa, expiryDate, "itsa", consent = false))))
+            thenGo(MultiConsent(Personal, uid, agentName, arn, Seq(ClientConsent(invitationIdItsa, expiryDate, Service.MtdIt, consent = false))))
         }
         "transition to GGUserIdNeeded when the ClientType is personal and there is no active session" in {
           def getInvitationDetails(uid: String) =
@@ -313,7 +313,7 @@ class ClientInvitationJourneyModelSpec extends UnitSpec with StateMatchers[State
 
           given(WarmUp(Trust, uid, arn, agentName, normalisedAgentName)) when
             submitWarmUp(getInvitationDetails, getNotSuspended)(Some(authorisedTrustNTClient)) should
-            thenGo(MultiConsent(Trust, uid, agentName, arn, Seq(ClientConsent(invitationIdTrustNT, expiryDate, "trustNT", consent = false))))
+            thenGo(MultiConsent(Trust, uid, agentName, arn, Seq(ClientConsent(invitationIdTrustNT, expiryDate, Service.TrustNT, consent = false))))
         }
         "transition to CannotFindRequest when the client has AffinityGroup Individual and no relevant enrolments" in {
           def getInvitationDetails(uid: String) =
@@ -392,8 +392,8 @@ class ClientInvitationJourneyModelSpec extends UnitSpec with StateMatchers[State
               agentName,
               arn,
               Set("HMRC-MTD-VAT"),
-              Seq(ClientConsent(invitationIdItsa, expiryDate, "itsa", consent = false)))) when submitSuspension(authorisedIndividualClient) should
-            thenGo(MultiConsent(Personal, uid, agentName, arn, Seq(ClientConsent(invitationIdItsa, expiryDate, "itsa", consent = false))))
+              Seq(ClientConsent(invitationIdItsa, expiryDate, Service.MtdIt, consent = false)))) when submitSuspension(authorisedIndividualClient) should
+            thenGo(MultiConsent(Personal, uid, agentName, arn, Seq(ClientConsent(invitationIdItsa, expiryDate, Service.MtdIt, consent = false))))
         }
       }
       "submitting intent to decline" should {
@@ -405,7 +405,7 @@ class ClientInvitationJourneyModelSpec extends UnitSpec with StateMatchers[State
 
           given(WarmUp(Personal, uid, arn, agentName, normalisedAgentName)) when
             submitWarmUpToDecline(getInvitationDetails, getNotSuspended)(authorisedIndividualClient) should
-            thenGo(ConfirmDecline(Personal, uid, agentName, arn, Seq(ClientConsent(invitationIdItsa, expiryDate, "itsa", consent = false))))
+            thenGo(ConfirmDecline(Personal, uid, agentName, arn, Seq(ClientConsent(invitationIdItsa, expiryDate, Service.MtdIt, consent = false))))
         }
 
         "transition to AuthorisationRequestAlreadyResponded when the invitation status is Rejected" in {
@@ -455,12 +455,12 @@ class ClientInvitationJourneyModelSpec extends UnitSpec with StateMatchers[State
             "agent name",
             arn,
             Seq(
-              ClientConsent(invitationIdItsa, expiryDate, "itsa", consent = false),
-              ClientConsent(invitationIdIrv, expiryDate, "afi", consent = false),
-              ClientConsent(invitationIdVat, expiryDate, "vat", consent = false),
-              ClientConsent(invitationIdTrust, expiryDate, "trust", consent = false),
-              ClientConsent(invitationIdTrustNT, expiryDate, "trustNT", consent = false),
-              ClientConsent(invitationIdTrust, expiryDate, "cgt", consent = false)
+              ClientConsent(invitationIdItsa, expiryDate, Service.MtdIt, consent = false),
+              ClientConsent(invitationIdIrv, expiryDate, Service.PersonalIncomeRecord, consent = false),
+              ClientConsent(invitationIdVat, expiryDate, Service.Vat, consent = false),
+              ClientConsent(invitationIdTrust, expiryDate, Service.Trust, consent = false),
+              ClientConsent(invitationIdTrustNT, expiryDate, Service.TrustNT, consent = false),
+              ClientConsent(invitationIdTrust, expiryDate, Service.CapitalGains, consent = false)
             )
           )) when
           submitConsents(authorisedIndividualClient)(
@@ -478,38 +478,15 @@ class ClientInvitationJourneyModelSpec extends UnitSpec with StateMatchers[State
               "uid",
               "agent name",
               Seq(
-                ClientConsent(invitationIdItsa, expiryDate, "itsa", consent = true),
-                ClientConsent(invitationIdIrv, expiryDate, "afi", consent = true),
-                ClientConsent(invitationIdVat, expiryDate, "vat", consent = true),
-                ClientConsent(invitationIdTrust, expiryDate, "trust", consent = true),
-                ClientConsent(invitationIdTrustNT, expiryDate, "trustNT", consent = true),
-                ClientConsent(invitationIdTrust, expiryDate, "cgt", consent = true)
+                ClientConsent(invitationIdItsa, expiryDate, Service.MtdIt, consent = true),
+                ClientConsent(invitationIdIrv, expiryDate, Service.PersonalIncomeRecord, consent = true),
+                ClientConsent(invitationIdVat, expiryDate, Service.Vat, consent = true),
+                ClientConsent(invitationIdTrust, expiryDate, Service.Trust, consent = true),
+                ClientConsent(invitationIdTrustNT, expiryDate, Service.TrustNT, consent = true),
+                ClientConsent(invitationIdTrust, expiryDate, Service.CapitalGains, consent = true)
               )
             )
           )
-      }
-      "throw an exception when the message key is not supported in the request" in {
-        intercept[IllegalStateException] {
-          given(
-            MultiConsent(
-              Personal,
-              "uid",
-              "agent name",
-              arn,
-              Seq(
-                ClientConsent(invitationIdItsa, expiryDate, "foo", consent = false)
-              )
-            )) when
-            submitConsents(authorisedIndividualClient)(
-              ConfirmedTerms(
-                itsaConsent = true,
-                afiConsent = true,
-                vatConsent = true,
-                trustConsent = true,
-                trustNTConsent = true,
-                cgtConsent = true,
-                pptConsent = true))
-        }.getMessage shouldBe "the service key was not supported"
       }
     }
     "at SingleConsent" should {
@@ -519,11 +496,11 @@ class ClientInvitationJourneyModelSpec extends UnitSpec with StateMatchers[State
             Personal,
             uid,
             "agent name",
-            ClientConsent(invitationIdItsa, expiryDate, "itsa", consent = false),
+            ClientConsent(invitationIdItsa, expiryDate, Service.MtdIt, consent = false),
             Seq(
-              ClientConsent(invitationIdItsa, expiryDate, "itsa", consent = false),
-              ClientConsent(invitationIdIrv, expiryDate, "afi", consent = true),
-              ClientConsent(invitationIdVat, expiryDate, "vat", consent = true)
+              ClientConsent(invitationIdItsa, expiryDate, Service.MtdIt, consent = false),
+              ClientConsent(invitationIdIrv, expiryDate, Service.PersonalIncomeRecord, consent = true),
+              ClientConsent(invitationIdVat, expiryDate, Service.Vat, consent = true)
             )
           )) when submitChangeConsents(authorisedIndividualClient)(
           ConfirmedTerms(
@@ -539,9 +516,9 @@ class ClientInvitationJourneyModelSpec extends UnitSpec with StateMatchers[State
             uid,
             "agent name",
             Seq(
-              ClientConsent(invitationIdItsa, expiryDate, "itsa", consent = true),
-              ClientConsent(invitationIdIrv, expiryDate, "afi", consent = true),
-              ClientConsent(invitationIdVat, expiryDate, "vat", consent = true)
+              ClientConsent(invitationIdItsa, expiryDate, Service.MtdIt, consent = true),
+              ClientConsent(invitationIdIrv, expiryDate, Service.PersonalIncomeRecord, consent = true),
+              ClientConsent(invitationIdVat, expiryDate, Service.Vat, consent = true)
             )
           )
         )
@@ -552,8 +529,8 @@ class ClientInvitationJourneyModelSpec extends UnitSpec with StateMatchers[State
             Personal,
             uid,
             "agent name",
-            ClientConsent(invitationIdIrv, expiryDate, "afi", consent = false),
-            Seq(ClientConsent(invitationIdIrv, expiryDate, "afi", consent = false))
+            ClientConsent(invitationIdIrv, expiryDate, Service.PersonalIncomeRecord, consent = false),
+            Seq(ClientConsent(invitationIdIrv, expiryDate, Service.PersonalIncomeRecord, consent = false))
           )) when submitChangeConsents(authorisedIndividualClient)(
           ConfirmedTerms(
             itsaConsent = false,
@@ -564,7 +541,7 @@ class ClientInvitationJourneyModelSpec extends UnitSpec with StateMatchers[State
             cgtConsent = false,
             pptConsent = true
           )) should thenGo(
-          CheckAnswers(Personal, uid, "agent name", Seq(ClientConsent(invitationIdIrv, expiryDate, "afi", consent = true)))
+          CheckAnswers(Personal, uid, "agent name", Seq(ClientConsent(invitationIdIrv, expiryDate, Service.PersonalIncomeRecord, consent = true)))
         )
       }
       "transition to CheckAnswers with changed vat consent" in {
@@ -573,8 +550,8 @@ class ClientInvitationJourneyModelSpec extends UnitSpec with StateMatchers[State
             Personal,
             uid,
             "agent name",
-            ClientConsent(invitationIdVat, expiryDate, "vat", consent = false),
-            Seq(ClientConsent(invitationIdVat, expiryDate, "vat", consent = false))
+            ClientConsent(invitationIdVat, expiryDate, Service.Vat, consent = false),
+            Seq(ClientConsent(invitationIdVat, expiryDate, Service.Vat, consent = false))
           )) when submitChangeConsents(authorisedIndividualClient)(
           ConfirmedTerms(
             itsaConsent = false,
@@ -585,7 +562,7 @@ class ClientInvitationJourneyModelSpec extends UnitSpec with StateMatchers[State
             cgtConsent = false,
             pptConsent = true,
           )) should thenGo(
-          CheckAnswers(Personal, uid, "agent name", Seq(ClientConsent(invitationIdVat, expiryDate, "vat", consent = true)))
+          CheckAnswers(Personal, uid, "agent name", Seq(ClientConsent(invitationIdVat, expiryDate, Service.Vat, consent = true)))
         )
       }
       "transition to CheckAnswers with changed trust consent" in {
@@ -594,8 +571,8 @@ class ClientInvitationJourneyModelSpec extends UnitSpec with StateMatchers[State
             Personal,
             uid,
             "agent name",
-            ClientConsent(invitationIdTrust, expiryDate, "trust", consent = false),
-            Seq(ClientConsent(invitationIdTrust, expiryDate, "trust", consent = false))
+            ClientConsent(invitationIdTrust, expiryDate, Service.Trust, consent = false),
+            Seq(ClientConsent(invitationIdTrust, expiryDate, Service.Trust, consent = false))
           )) when submitChangeConsents(authorisedIndividualClient)(
           ConfirmedTerms(
             itsaConsent = false,
@@ -606,7 +583,7 @@ class ClientInvitationJourneyModelSpec extends UnitSpec with StateMatchers[State
             cgtConsent = false,
             pptConsent = true
           )) should thenGo(
-          CheckAnswers(Personal, uid, "agent name", Seq(ClientConsent(invitationIdTrust, expiryDate, "trust", consent = true)))
+          CheckAnswers(Personal, uid, "agent name", Seq(ClientConsent(invitationIdTrust, expiryDate, Service.Trust, consent = true)))
         )
       }
 
@@ -616,8 +593,8 @@ class ClientInvitationJourneyModelSpec extends UnitSpec with StateMatchers[State
             Personal,
             uid,
             "agent name",
-            ClientConsent(invitationIdCgt, expiryDate, "cgt", consent = false),
-            Seq(ClientConsent(invitationIdCgt, expiryDate, "cgt", consent = false))
+            ClientConsent(invitationIdCgt, expiryDate, Service.CapitalGains, consent = false),
+            Seq(ClientConsent(invitationIdCgt, expiryDate, Service.CapitalGains, consent = false))
           )) when submitChangeConsents(authorisedIndividualClient)(
           ConfirmedTerms(
             itsaConsent = false,
@@ -628,7 +605,7 @@ class ClientInvitationJourneyModelSpec extends UnitSpec with StateMatchers[State
             cgtConsent = true,
             pptConsent = true
           )) should thenGo(
-          CheckAnswers(Personal, uid, "agent name", Seq(ClientConsent(invitationIdCgt, expiryDate, "cgt", consent = true)))
+          CheckAnswers(Personal, uid, "agent name", Seq(ClientConsent(invitationIdCgt, expiryDate, Service.CapitalGains, consent = true)))
         )
       }
 
@@ -638,8 +615,8 @@ class ClientInvitationJourneyModelSpec extends UnitSpec with StateMatchers[State
             Personal,
             uid,
             "agent name",
-            ClientConsent(invitationIdPpt, expiryDate, "ppt", consent = false),
-            Seq(ClientConsent(invitationIdPpt, expiryDate, "ppt", consent = false))
+            ClientConsent(invitationIdPpt, expiryDate, Service.Ppt, consent = false),
+            Seq(ClientConsent(invitationIdPpt, expiryDate, Service.Ppt, consent = false))
           )) when submitChangeConsents(authorisedIndividualClient)(
           ConfirmedTerms(
             itsaConsent = false,
@@ -650,7 +627,7 @@ class ClientInvitationJourneyModelSpec extends UnitSpec with StateMatchers[State
             cgtConsent = true,
             pptConsent = true
           )) should thenGo(
-          CheckAnswers(Personal, uid, "agent name", Seq(ClientConsent(invitationIdPpt, expiryDate, "ppt", consent = true)))
+          CheckAnswers(Personal, uid, "agent name", Seq(ClientConsent(invitationIdPpt, expiryDate, Service.Ppt, consent = true)))
         )
       }
     }
@@ -665,17 +642,17 @@ class ClientInvitationJourneyModelSpec extends UnitSpec with StateMatchers[State
             uid,
             "agent name",
             Seq(
-              ClientConsent(invitationIdItsa, expiryDate, "itsa", consent = true),
-              ClientConsent(invitationIdIrv, expiryDate, "afi", consent = true),
-              ClientConsent(invitationIdVat, expiryDate, "vat", consent = true)
+              ClientConsent(invitationIdItsa, expiryDate, Service.MtdIt, consent = true),
+              ClientConsent(invitationIdIrv, expiryDate, Service.PersonalIncomeRecord, consent = true),
+              ClientConsent(invitationIdVat, expiryDate, Service.Vat, consent = true)
             )
           )) when submitCheckAnswers(acceptInvitation)(rejectInvitation)(authorisedIndividualClient) should thenGo(
           InvitationsAccepted(
             "agent name",
             Seq(
-              ClientConsent(invitationIdItsa, expiryDate, "itsa", consent = true),
-              ClientConsent(invitationIdIrv, expiryDate, "afi", consent = true),
-              ClientConsent(invitationIdVat, expiryDate, "vat", consent = true)
+              ClientConsent(invitationIdItsa, expiryDate, Service.MtdIt, consent = true),
+              ClientConsent(invitationIdIrv, expiryDate, Service.PersonalIncomeRecord, consent = true),
+              ClientConsent(invitationIdVat, expiryDate, Service.Vat, consent = true)
             ),
             Personal
           ))
@@ -690,19 +667,19 @@ class ClientInvitationJourneyModelSpec extends UnitSpec with StateMatchers[State
             uid,
             "agent name",
             Seq(
-              ClientConsent(invitationIdItsa, expiryDate, "itsa", consent = false),
-              ClientConsent(invitationIdIrv, expiryDate, "afi", consent = false),
-              ClientConsent(invitationIdVat, expiryDate, "vat", consent = false),
-              ClientConsent(invitationIdTrust, expiryDate, "trust", consent = false)
+              ClientConsent(invitationIdItsa, expiryDate, Service.MtdIt, consent = false),
+              ClientConsent(invitationIdIrv, expiryDate, Service.PersonalIncomeRecord, consent = false),
+              ClientConsent(invitationIdVat, expiryDate, Service.Vat, consent = false),
+              ClientConsent(invitationIdTrust, expiryDate, Service.Trust, consent = false)
             )
           )) when submitCheckAnswers(acceptInvitation)(rejectInvitation)(authorisedIndividualClient) should thenGo(
           InvitationsDeclined(
             "agent name",
             Seq(
-              ClientConsent(invitationIdItsa, expiryDate, "itsa", consent = false),
-              ClientConsent(invitationIdIrv, expiryDate, "afi", consent = false),
-              ClientConsent(invitationIdVat, expiryDate, "vat", consent = false),
-              ClientConsent(invitationIdTrust, expiryDate, "trust", consent = false)
+              ClientConsent(invitationIdItsa, expiryDate, Service.MtdIt, consent = false),
+              ClientConsent(invitationIdIrv, expiryDate, Service.PersonalIncomeRecord, consent = false),
+              ClientConsent(invitationIdVat, expiryDate, Service.Vat, consent = false),
+              ClientConsent(invitationIdTrust, expiryDate, Service.Trust, consent = false)
             ),
             Personal
           ))
@@ -718,19 +695,19 @@ class ClientInvitationJourneyModelSpec extends UnitSpec with StateMatchers[State
             uid,
             "agent name",
             Seq(
-              ClientConsent(invitationIdItsa, expiryDate, "itsa", consent = true),
-              ClientConsent(invitationIdIrv, expiryDate, "afi", consent = true),
-              ClientConsent(invitationIdVat, expiryDate, "vat", consent = true)
+              ClientConsent(invitationIdItsa, expiryDate, Service.MtdIt, consent = true),
+              ClientConsent(invitationIdIrv, expiryDate, Service.PersonalIncomeRecord, consent = true),
+              ClientConsent(invitationIdVat, expiryDate, Service.Vat, consent = true)
             )
           )) when submitCheckAnswers(acceptInvitation)(rejectInvitation)(authorisedIndividualClient) should thenGo(
           SomeResponsesFailed(
             "agent name",
             Seq(
-              ClientConsent(invitationIdItsa, expiryDate, "itsa", consent = true)
+              ClientConsent(invitationIdItsa, expiryDate, Service.MtdIt, consent = true)
             ),
             Seq(
-              ClientConsent(invitationIdIrv, expiryDate, "afi", consent = true, processed = true),
-              ClientConsent(invitationIdVat, expiryDate, "vat", consent = true, processed = true)
+              ClientConsent(invitationIdIrv, expiryDate, Service.PersonalIncomeRecord, consent = true, processed = true),
+              ClientConsent(invitationIdVat, expiryDate, Service.Vat, consent = true, processed = true)
             ),
             Personal
           ))
@@ -745,9 +722,9 @@ class ClientInvitationJourneyModelSpec extends UnitSpec with StateMatchers[State
             uid,
             "agent name",
             Seq(
-              ClientConsent(invitationIdItsa, expiryDate, "itsa", consent = true),
-              ClientConsent(invitationIdIrv, expiryDate, "afi", consent = true),
-              ClientConsent(invitationIdVat, expiryDate, "vat", consent = true)
+              ClientConsent(invitationIdItsa, expiryDate, Service.MtdIt, consent = true),
+              ClientConsent(invitationIdIrv, expiryDate, Service.PersonalIncomeRecord, consent = true),
+              ClientConsent(invitationIdVat, expiryDate, Service.Vat, consent = true)
             )
           )) when submitCheckAnswers(acceptInvitation)(rejectInvitation)(authorisedIndividualClient) should thenGo(AllResponsesFailed)
       }
@@ -755,21 +732,15 @@ class ClientInvitationJourneyModelSpec extends UnitSpec with StateMatchers[State
 
     "at state CheckAnswers" should {
       "transition to SingleConsent " in {
-        given(CheckAnswers(Personal, "uid", "agent name", Seq(ClientConsent(invitationIdItsa, expiryDate, "itsa", consent = true)))) when
-          submitCheckAnswersChange("itsa")(authorisedIndividualClient) should thenGo(
+        given(CheckAnswers(Personal, "uid", "agent name", Seq(ClientConsent(invitationIdItsa, expiryDate, Service.MtdIt, consent = true)))) when
+          submitCheckAnswersChange(Service.MtdIt)(authorisedIndividualClient) should thenGo(
           SingleConsent(
             Personal,
             "uid",
             "agent name",
-            ClientConsent(invitationIdItsa, expiryDate, "itsa", consent = true),
-            Seq(ClientConsent(invitationIdItsa, expiryDate, "itsa", consent = true))
+            ClientConsent(invitationIdItsa, expiryDate, Service.MtdIt, consent = true),
+            Seq(ClientConsent(invitationIdItsa, expiryDate, Service.MtdIt, consent = true))
           ))
-      }
-      "throw an exception when the key for the consent is not found" in {
-        intercept[IllegalStateException] {
-          given(CheckAnswers(Personal, "uid", "agent name", Seq(ClientConsent(invitationIdItsa, expiryDate, "itsa", consent = true)))) when
-            submitCheckAnswersChange("foo")(authorisedIndividualClient)
-        }.getMessage shouldBe "the key for this consent was not found"
       }
     }
     "at state ConfirmDecline" should {
@@ -784,18 +755,18 @@ class ClientInvitationJourneyModelSpec extends UnitSpec with StateMatchers[State
             "agent pearson",
             arn,
             Seq(
-              ClientConsent(invitationIdItsa, expiryDate, "itsa", consent = false),
-              ClientConsent(invitationIdIrv, expiryDate, "afi", consent = false),
-              ClientConsent(invitationIdVat, expiryDate, "vat", consent = false)
+              ClientConsent(invitationIdItsa, expiryDate, Service.MtdIt, consent = false),
+              ClientConsent(invitationIdIrv, expiryDate, Service.PersonalIncomeRecord, consent = false),
+              ClientConsent(invitationIdVat, expiryDate, Service.Vat, consent = false)
             )
           )) when
           submitConfirmDecline(rejectInvitation)(authorisedIndividualClient)(Confirmation(true)) should thenGo(
           InvitationsDeclined(
             "agent pearson",
             Seq(
-              ClientConsent(invitationIdItsa, expiryDate, "itsa", consent = false),
-              ClientConsent(invitationIdIrv, expiryDate, "afi", consent = false),
-              ClientConsent(invitationIdVat, expiryDate, "vat", consent = false)
+              ClientConsent(invitationIdItsa, expiryDate, Service.MtdIt, consent = false),
+              ClientConsent(invitationIdIrv, expiryDate, Service.PersonalIncomeRecord, consent = false),
+              ClientConsent(invitationIdVat, expiryDate, Service.Vat, consent = false)
             ),
             Personal
           )
@@ -812,9 +783,9 @@ class ClientInvitationJourneyModelSpec extends UnitSpec with StateMatchers[State
             "agent pearson",
             arn,
             Seq(
-              ClientConsent(invitationIdItsa, expiryDate, "itsa", consent = false),
-              ClientConsent(invitationIdIrv, expiryDate, "afi", consent = false),
-              ClientConsent(invitationIdVat, expiryDate, "vat", consent = false)
+              ClientConsent(invitationIdItsa, expiryDate, Service.MtdIt, consent = false),
+              ClientConsent(invitationIdIrv, expiryDate, Service.PersonalIncomeRecord, consent = false),
+              ClientConsent(invitationIdVat, expiryDate, Service.Vat, consent = false)
             )
           )) when
           submitConfirmDecline(rejectInvitation)(authorisedIndividualClient)(Confirmation(false)) should thenGo(
@@ -824,9 +795,9 @@ class ClientInvitationJourneyModelSpec extends UnitSpec with StateMatchers[State
             "agent pearson",
             arn,
             Seq(
-              ClientConsent(invitationIdItsa, expiryDate, "itsa", consent = false),
-              ClientConsent(invitationIdIrv, expiryDate, "afi", consent = false),
-              ClientConsent(invitationIdVat, expiryDate, "vat", consent = false)
+              ClientConsent(invitationIdItsa, expiryDate, Service.MtdIt, consent = false),
+              ClientConsent(invitationIdIrv, expiryDate, Service.PersonalIncomeRecord, consent = false),
+              ClientConsent(invitationIdVat, expiryDate, Service.Vat, consent = false)
             )
           )
         )
@@ -838,13 +809,13 @@ class ClientInvitationJourneyModelSpec extends UnitSpec with StateMatchers[State
         given(
           SomeResponsesFailed(
             "Mr agent",
-            Seq(ClientConsent(invitationIdItsa, expiryDate, "itsa", consent = true)),
-            Seq(ClientConsent(invitationIdIrv, expiryDate, "afi", consent = true, processed = true)),
+            Seq(ClientConsent(invitationIdItsa, expiryDate, Service.MtdIt, consent = true)),
+            Seq(ClientConsent(invitationIdIrv, expiryDate, Service.PersonalIncomeRecord, consent = true, processed = true)),
             Personal
           )) when continueSomeResponsesFailed(authorisedIndividualClient) should thenGo(
           InvitationsAccepted(
             "Mr agent",
-            Seq(ClientConsent(InvitationId("B1BEOZEO7MNO6"), expiryDate, "afi", consent = true, processed = true)),
+            Seq(ClientConsent(InvitationId("B1BEOZEO7MNO6"), expiryDate, Service.PersonalIncomeRecord, consent = true, processed = true)),
             Personal))
       }
     }

--- a/test/journeys/ClientInvitationJourneyStateFormatsSpec.scala
+++ b/test/journeys/ClientInvitationJourneyStateFormatsSpec.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.agentinvitationsfrontend.journeys.ClientInvitationJourneyStat
 import uk.gov.hmrc.agentinvitationsfrontend.journeys.ClientInvitationJourneyStateFormats._
 import uk.gov.hmrc.agentinvitationsfrontend.models._
 import uk.gov.hmrc.agentinvitationsfrontend.models.ClientType.Personal
-import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, InvitationId}
+import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, InvitationId, Service}
 import support.UnitSpec
 
 class ClientInvitationJourneyStateFormatsSpec extends UnitSpec {
@@ -40,7 +40,7 @@ class ClientInvitationJourneyStateFormatsSpec extends UnitSpec {
                            |  "value": "A1BEOZEO7MNO6"
                            |  },
                            |"expiryDate": "2010-01-01",
-                           |"serviceKey": "itsa",
+                           |"service": "HMRC-MTD-IT",
                            |"consent": true,
                            |"processed": false,
                            |"isAltItsa":false
@@ -49,7 +49,7 @@ class ClientInvitationJourneyStateFormatsSpec extends UnitSpec {
                            |  "value": "B1BEOZEO7MNO6"
                            |  },
                            |"expiryDate": "2010-02-02",
-                           |"serviceKey": "afi",
+                           |"service": "PERSONAL-INCOME-RECORD",
                            |"consent": true,
                            |"processed": false,
                            |"isAltItsa":false
@@ -116,11 +116,11 @@ class ClientInvitationJourneyStateFormatsSpec extends UnitSpec {
           "agent name",
           Arn("1234"),
           Seq(
-            ClientConsent(InvitationId("A1BEOZEO7MNO6"), LocalDate.parse("2010-01-01"), "itsa", consent = true),
+            ClientConsent(InvitationId("A1BEOZEO7MNO6"), LocalDate.parse("2010-01-01"), Service.MtdIt, consent = true),
             ClientConsent(
               InvitationId("B1BEOZEO7MNO6"),
               LocalDate.parse("2010-02-02"),
-              "afi",
+              Service.PersonalIncomeRecord,
               consent = true
             )
           )
@@ -143,26 +143,26 @@ class ClientInvitationJourneyStateFormatsSpec extends UnitSpec {
           ClientConsent(
             InvitationId("B1BEOZEO7MNO6"),
             LocalDate.parse("2010-02-02"),
-            "afi",
+            Service.PersonalIncomeRecord,
             consent = true
           ),
           Seq(
             ClientConsent(
               InvitationId("A1BEOZEO7MNO6"),
               LocalDate.parse("2010-01-01"),
-              "itsa",
+              Service.MtdIt,
               consent = true
             ),
             ClientConsent(
               InvitationId("B1BEOZEO7MNO6"),
               LocalDate.parse("2010-02-02"),
-              "afi",
+              Service.PersonalIncomeRecord,
               consent = true
             )
           )
         )
         val json = Json.parse(
-          s"""{"state":"SingleConsent","properties":{"clientType": "personal", "uid": "uid", "agentName": "agent name", "consent": {"invitationId": {"value": "B1BEOZEO7MNO6"}, "expiryDate": "2010-02-02", "serviceKey": "afi", "consent": true, "processed": false, "isAltItsa":false}, $jsonConsents}}""".stripMargin)
+          s"""{"state":"SingleConsent","properties":{"clientType": "personal", "uid": "uid", "agentName": "agent name", "consent": {"invitationId": {"value": "B1BEOZEO7MNO6"}, "expiryDate": "2010-02-02", "service": "PERSONAL-INCOME-RECORD", "consent": true, "processed": false, "isAltItsa":false}, $jsonConsents}}""".stripMargin)
 
         Json.toJson(state: State) shouldBe json
         json.as[State] shouldBe state
@@ -177,13 +177,13 @@ class ClientInvitationJourneyStateFormatsSpec extends UnitSpec {
             ClientConsent(
               InvitationId("A1BEOZEO7MNO6"),
               LocalDate.parse("2010-01-01"),
-              "itsa",
+              Service.MtdIt,
               consent = true
             ),
             ClientConsent(
               InvitationId("B1BEOZEO7MNO6"),
               LocalDate.parse("2010-02-02"),
-              "afi",
+              Service.PersonalIncomeRecord,
               consent = true
             )
           )
@@ -201,13 +201,13 @@ class ClientInvitationJourneyStateFormatsSpec extends UnitSpec {
             ClientConsent(
               InvitationId("A1BEOZEO7MNO6"),
               LocalDate.parse("2010-01-01"),
-              "itsa",
+              Service.MtdIt,
               consent = true
             ),
             ClientConsent(
               InvitationId("B1BEOZEO7MNO6"),
               LocalDate.parse("2010-02-02"),
-              "afi",
+              Service.PersonalIncomeRecord,
               consent = true
             )
           ),
@@ -226,13 +226,13 @@ class ClientInvitationJourneyStateFormatsSpec extends UnitSpec {
             ClientConsent(
               InvitationId("A1BEOZEO7MNO6"),
               LocalDate.parse("2010-01-01"),
-              "itsa",
+              Service.MtdIt,
               consent = true
             ),
             ClientConsent(
               InvitationId("B1BEOZEO7MNO6"),
               LocalDate.parse("2010-02-02"),
-              "afi",
+              Service.PersonalIncomeRecord,
               consent = true
             )
           ),
@@ -261,7 +261,7 @@ class ClientInvitationJourneyStateFormatsSpec extends UnitSpec {
             ClientConsent(
               InvitationId("A1BEOZEO7MNO6"),
               LocalDate.parse("2010-01-01"),
-              "itsa",
+              Service.MtdIt,
               consent = true
             )
           ),
@@ -269,7 +269,7 @@ class ClientInvitationJourneyStateFormatsSpec extends UnitSpec {
             ClientConsent(
               InvitationId("B1BEOZEO7MNO6"),
               LocalDate.parse("2010-02-02"),
-              "afi",
+              Service.PersonalIncomeRecord,
               consent = true,
               processed = true
             )),
@@ -282,7 +282,7 @@ class ClientInvitationJourneyStateFormatsSpec extends UnitSpec {
                         |    "value": "A1BEOZEO7MNO6"
                         |  },
                         |  "expiryDate": "2010-01-01",
-                        |  "serviceKey": "itsa",
+                        |  "service": "HMRC-MTD-IT",
                         |  "consent": true,
                         |  "processed": false,
                         |  "isAltItsa":false
@@ -292,7 +292,7 @@ class ClientInvitationJourneyStateFormatsSpec extends UnitSpec {
                         |    "value": "B1BEOZEO7MNO6"
                         |  },
                         |  "expiryDate": "2010-02-02",
-                        |  "serviceKey": "afi",
+                        |  "service": "PERSONAL-INCOME-RECORD",
                         |  "consent": true,
                         |  "processed": true,
                         |  "isAltItsa":false
@@ -312,13 +312,13 @@ class ClientInvitationJourneyStateFormatsSpec extends UnitSpec {
             ClientConsent(
               InvitationId("A1BEOZEO7MNO6"),
               LocalDate.parse("2010-01-01"),
-              "itsa",
+              Service.MtdIt,
               consent = true
             ),
             ClientConsent(
               InvitationId("B1BEOZEO7MNO6"),
               LocalDate.parse("2010-02-02"),
-              "afi",
+              Service.PersonalIncomeRecord,
               consent = true
             )
           )

--- a/test/models/ClientConsentsJourneyStateSpec.scala
+++ b/test/models/ClientConsentsJourneyStateSpec.scala
@@ -18,7 +18,7 @@ package models
 
 import java.time.LocalDate
 import uk.gov.hmrc.agentinvitationsfrontend.models.{ClientConsent, ClientConsentsJourneyState}
-import uk.gov.hmrc.agentmtdidentifiers.model.InvitationId
+import uk.gov.hmrc.agentmtdidentifiers.model.{InvitationId, Service}
 import support.UnitSpec
 
 class ClientConsentsJourneyStateSpec extends UnitSpec {
@@ -29,27 +29,27 @@ class ClientConsentsJourneyStateSpec extends UnitSpec {
     "have allDeclinedProcessed" in {
       ClientConsentsJourneyState(
         Seq(
-          ClientConsent(InvitationId("AG1UGUKTPNJ7W"), expiryDate, "itsa", consent = false, true),
-          ClientConsent(InvitationId("B9SCS2T4NZBAX"), expiryDate, "afi", consent = false, true),
-          ClientConsent(InvitationId("CZTW1KY6RTAAT"), expiryDate, "vat", consent = false, true)
+          ClientConsent(InvitationId("AG1UGUKTPNJ7W"), expiryDate, Service.MtdIt, consent = false, true),
+          ClientConsent(InvitationId("B9SCS2T4NZBAX"), expiryDate, Service.PersonalIncomeRecord, consent = false, true),
+          ClientConsent(InvitationId("CZTW1KY6RTAAT"), expiryDate, Service.Vat, consent = false, true)
         ),
         Some("My Agency Name")
       ).allDeclinedProcessed shouldBe true
 
       ClientConsentsJourneyState(
         Seq(
-          ClientConsent(InvitationId("AG1UGUKTPNJ7W"), expiryDate, "itsa", consent = false, true),
-          ClientConsent(InvitationId("B9SCS2T4NZBAX"), expiryDate, "afi", consent = false, false),
-          ClientConsent(InvitationId("CZTW1KY6RTAAT"), expiryDate, "vat", consent = false, true)
+          ClientConsent(InvitationId("AG1UGUKTPNJ7W"), expiryDate, Service.MtdIt, consent = false, true),
+          ClientConsent(InvitationId("B9SCS2T4NZBAX"), expiryDate, Service.PersonalIncomeRecord, consent = false, false),
+          ClientConsent(InvitationId("CZTW1KY6RTAAT"), expiryDate, Service.Vat, consent = false, true)
         ),
         Some("My Agency Name")
       ).allDeclinedProcessed shouldBe true
 
       ClientConsentsJourneyState(
         Seq(
-          ClientConsent(InvitationId("AG1UGUKTPNJ7W"), expiryDate, "itsa", consent = true, true),
-          ClientConsent(InvitationId("B9SCS2T4NZBAX"), expiryDate, "afi", consent = true, true),
-          ClientConsent(InvitationId("CZTW1KY6RTAAT"), expiryDate, "vat", consent = true, true)
+          ClientConsent(InvitationId("AG1UGUKTPNJ7W"), expiryDate, Service.MtdIt, consent = true, true),
+          ClientConsent(InvitationId("B9SCS2T4NZBAX"), expiryDate, Service.PersonalIncomeRecord, consent = true, true),
+          ClientConsent(InvitationId("CZTW1KY6RTAAT"), expiryDate, Service.Vat, consent = true, true)
         ),
         Some("My Agency Name")
       ).allDeclinedProcessed shouldBe false
@@ -57,27 +57,27 @@ class ClientConsentsJourneyStateSpec extends UnitSpec {
     "have allProcessed" in {
       ClientConsentsJourneyState(
         Seq(
-          ClientConsent(InvitationId("AG1UGUKTPNJ7W"), expiryDate, "itsa", consent = false, true),
-          ClientConsent(InvitationId("B9SCS2T4NZBAX"), expiryDate, "afi", consent = true, true),
-          ClientConsent(InvitationId("CZTW1KY6RTAAT"), expiryDate, "vat", consent = true, true)
+          ClientConsent(InvitationId("AG1UGUKTPNJ7W"), expiryDate, Service.MtdIt, consent = false, true),
+          ClientConsent(InvitationId("B9SCS2T4NZBAX"), expiryDate, Service.PersonalIncomeRecord, consent = true, true),
+          ClientConsent(InvitationId("CZTW1KY6RTAAT"), expiryDate, Service.Vat, consent = true, true)
         ),
         Some("My Agency Name")
       ).allProcessed shouldBe true
 
       ClientConsentsJourneyState(
         Seq(
-          ClientConsent(InvitationId("AG1UGUKTPNJ7W"), expiryDate, "itsa", consent = false, true),
-          ClientConsent(InvitationId("B9SCS2T4NZBAX"), expiryDate, "afi", consent = true, false),
-          ClientConsent(InvitationId("CZTW1KY6RTAAT"), expiryDate, "vat", consent = true, true)
+          ClientConsent(InvitationId("AG1UGUKTPNJ7W"), expiryDate, Service.MtdIt, consent = false, true),
+          ClientConsent(InvitationId("B9SCS2T4NZBAX"), expiryDate, Service.PersonalIncomeRecord, consent = true, false),
+          ClientConsent(InvitationId("CZTW1KY6RTAAT"), expiryDate, Service.Vat, consent = true, true)
         ),
         Some("My Agency Name")
       ).allProcessed shouldBe false
 
       ClientConsentsJourneyState(
         Seq(
-          ClientConsent(InvitationId("AG1UGUKTPNJ7W"), expiryDate, "itsa", consent = false, processed = true),
-          ClientConsent(InvitationId("B9SCS2T4NZBAX"), expiryDate, "afi", consent = false, processed = true),
-          ClientConsent(InvitationId("CZTW1KY6RTAAT"), expiryDate, "vat", consent = false, processed = true)
+          ClientConsent(InvitationId("AG1UGUKTPNJ7W"), expiryDate, Service.MtdIt, consent = false, processed = true),
+          ClientConsent(InvitationId("B9SCS2T4NZBAX"), expiryDate, Service.PersonalIncomeRecord, consent = false, processed = true),
+          ClientConsent(InvitationId("CZTW1KY6RTAAT"), expiryDate, Service.Vat, consent = false, processed = true)
         ),
         Some("My Agency Name")
       ).allProcessed shouldBe true
@@ -85,18 +85,18 @@ class ClientConsentsJourneyStateSpec extends UnitSpec {
     "have allAcceptanceFailed" in {
       ClientConsentsJourneyState(
         Seq(
-          ClientConsent(InvitationId("AG1UGUKTPNJ7W"), expiryDate, "itsa", consent = false, processed = true),
-          ClientConsent(InvitationId("B9SCS2T4NZBAX"), expiryDate, "afi", consent = true, processed = true),
-          ClientConsent(InvitationId("CZTW1KY6RTAAT"), expiryDate, "vat", consent = true, processed = true)
+          ClientConsent(InvitationId("AG1UGUKTPNJ7W"), expiryDate, Service.MtdIt, consent = false, processed = true),
+          ClientConsent(InvitationId("B9SCS2T4NZBAX"), expiryDate, Service.PersonalIncomeRecord, consent = true, processed = true),
+          ClientConsent(InvitationId("CZTW1KY6RTAAT"), expiryDate, Service.Vat, consent = true, processed = true)
         ),
         Some("My Agency Name")
       ).allAcceptanceFailed shouldBe false
 
       ClientConsentsJourneyState(
         Seq(
-          ClientConsent(InvitationId("AG1UGUKTPNJ7W"), expiryDate, "itsa", consent = true, processed = false),
-          ClientConsent(InvitationId("B9SCS2T4NZBAX"), expiryDate, "afi", consent = true, processed = false),
-          ClientConsent(InvitationId("CZTW1KY6RTAAT"), expiryDate, "vat", consent = true, processed = false)
+          ClientConsent(InvitationId("AG1UGUKTPNJ7W"), expiryDate, Service.MtdIt, consent = true, processed = false),
+          ClientConsent(InvitationId("B9SCS2T4NZBAX"), expiryDate, Service.PersonalIncomeRecord, consent = true, processed = false),
+          ClientConsent(InvitationId("CZTW1KY6RTAAT"), expiryDate, Service.Vat, consent = true, processed = false)
         ),
         Some("My Agency Name")
       ).allAcceptanceFailed shouldBe true
@@ -104,18 +104,18 @@ class ClientConsentsJourneyStateSpec extends UnitSpec {
     "have someAcceptanceFailed" in {
       ClientConsentsJourneyState(
         Seq(
-          ClientConsent(InvitationId("AG1UGUKTPNJ7W"), expiryDate, "itsa", consent = false, processed = true),
-          ClientConsent(InvitationId("B9SCS2T4NZBAX"), expiryDate, "afi", consent = true, processed = false),
-          ClientConsent(InvitationId("CZTW1KY6RTAAT"), expiryDate, "vat", consent = true, processed = true)
+          ClientConsent(InvitationId("AG1UGUKTPNJ7W"), expiryDate, Service.MtdIt, consent = false, processed = true),
+          ClientConsent(InvitationId("B9SCS2T4NZBAX"), expiryDate, Service.PersonalIncomeRecord, consent = true, processed = false),
+          ClientConsent(InvitationId("CZTW1KY6RTAAT"), expiryDate, Service.Vat, consent = true, processed = true)
         ),
         Some("My Agency Name")
       ).someAcceptanceFailed shouldBe true
 
       ClientConsentsJourneyState(
         Seq(
-          ClientConsent(InvitationId("AG1UGUKTPNJ7W"), expiryDate, "itsa", consent = false, processed = true),
-          ClientConsent(InvitationId("B9SCS2T4NZBAX"), expiryDate, "afi", consent = true, processed = true),
-          ClientConsent(InvitationId("CZTW1KY6RTAAT"), expiryDate, "vat", consent = true, processed = true)
+          ClientConsent(InvitationId("AG1UGUKTPNJ7W"), expiryDate, Service.MtdIt, consent = false, processed = true),
+          ClientConsent(InvitationId("B9SCS2T4NZBAX"), expiryDate, Service.PersonalIncomeRecord, consent = true, processed = true),
+          ClientConsent(InvitationId("CZTW1KY6RTAAT"), expiryDate, Service.Vat, consent = true, processed = true)
         ),
         Some("My Agency Name")
       ).someAcceptanceFailed shouldBe false


### PR DESCRIPTION
It turns out that when we select a string from the message list based on service, there are two different ways this is done:
by service key e.g. some-page.HMRC-MTD-VAT.h1
by so-called 'serviceMessageKey' which is another (different obvs) mapping between services and strings, so you have e.g. some-page.vat.h1
These 'serviceMessageKeys' also infested logic as well as views, where we pattern matched on the strings rather than on the services themselves (losing type safety and exhaustivity checks)
The 'serviceMessageKey' mapping sadly is still in there in a few places as I didn't want to rename hundreds of strings in the message files, but its usage is removed wherever possible and pushed to the edges (i.e. the views).
This work of renaming message keys would be a worthy thing to do one day so we can finally kill 'serviceMessageKey' once and for all (and it would be a step towards modularising agents invitations)