### PR TITLE
APB-7249 [CS] fix CYA change link bug

### DIFF
--- a/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/ClientInvitationJourneyController.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/controllers/ClientInvitationJourneyController.scala
@@ -211,8 +211,20 @@ class ClientInvitationJourneyController @Inject()(
       )
       .redirect
 
-  def submitCheckAnswersChange(serviceKey: String): Action[AnyContent] =
-    actions.whenAuthorisedWithRetrievals(AsClient)(Transitions.submitCheckAnswersChange(Service.forId(serviceKey))).redirect
+  def submitCheckAnswersChange(serviceMessageKey: String): Action[AnyContent] = {
+    // needed to avoid changing the CYA url - because the serviceMessageKey is not the same as serviceId/serviceKey
+    val service: Service = serviceMessageKey match {
+      case "itsa"    => Service.MtdIt
+      case "afi"     => Service.PersonalIncomeRecord
+      case "vat"     => Service.Vat
+      case "trust"   => Service.Trust
+      case "trustNT" => Service.TrustNT
+      case "cgt"     => Service.CapitalGains
+      case "ppt"     => Service.Ppt
+      case s         => throw new IllegalArgumentException(s"not a supported service message key: $s")
+    }
+    actions.whenAuthorisedWithRetrievals(AsClient)(Transitions.submitCheckAnswersChange(service)).redirect
+  }
 
   val submitWarmUpConfirmDecline: Action[AnyContent] =
     actions

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/models/Services.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/models/Services.scala
@@ -79,7 +79,7 @@ object Services {
       .getOrElse(throw new IllegalArgumentException(s"No service corresponding to prefix '$prefix'"))
   }
 
-  def clientIdType(service: Service) =
+  def clientIdType(service: Service): String =
     service match {
       case Service.MtdIt                => "ni"
       case Service.Vat                  => "vrn"
@@ -101,5 +101,5 @@ object Services {
   }
 
   // TODO move this to agent-mtd-identifiers
-  def createTaxIdentifier(idType: String, id: String) = ClientIdType.forId(idType).createUnderlying(id)
+  def createTaxIdentifier(idType: String, id: String): TaxIdentifier = ClientIdType.forId(idType).createUnderlying(id)
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -9,7 +9,7 @@ object AppDependencies {
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-28" % bootstrapVer,
     "uk.gov.hmrc"       %% "play-frontend-hmrc"         % "7.7.0-play-28",
     "uk.gov.hmrc"       %% "play-fsm"                   % "0.89.0-play-28",
-    "uk.gov.hmrc"       %% "agent-mtd-identifiers"      % "1.2.0",
+    "uk.gov.hmrc"       %% "agent-mtd-identifiers"      % "1.9.0",
     "uk.gov.hmrc"       %% "agent-kenshoo-monitoring"   % "5.4.0",
     "uk.gov.hmrc"       %% "play-partials"              % "8.4.0-play-28",
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"         % mongoVersion

--- a/test/models/ClientConsentsJourneyStateSpec.scala
+++ b/test/models/ClientConsentsJourneyStateSpec.scala
@@ -23,33 +23,33 @@ import support.UnitSpec
 
 class ClientConsentsJourneyStateSpec extends UnitSpec {
 
-  val expiryDate = LocalDate.now()
+  val expiryDate: LocalDate = LocalDate.now()
 
   "ClientConsentsJourneyState" should {
     "have allDeclinedProcessed" in {
       ClientConsentsJourneyState(
         Seq(
-          ClientConsent(InvitationId("AG1UGUKTPNJ7W"), expiryDate, Service.MtdIt, consent = false, true),
-          ClientConsent(InvitationId("B9SCS2T4NZBAX"), expiryDate, Service.PersonalIncomeRecord, consent = false, true),
-          ClientConsent(InvitationId("CZTW1KY6RTAAT"), expiryDate, Service.Vat, consent = false, true)
+          ClientConsent(InvitationId("AG1UGUKTPNJ7W"), expiryDate, Service.MtdIt, consent = false, processed = true),
+          ClientConsent(InvitationId("B9SCS2T4NZBAX"), expiryDate, Service.PersonalIncomeRecord, consent = false, processed = true),
+          ClientConsent(InvitationId("CZTW1KY6RTAAT"), expiryDate, Service.Vat, consent = false, processed = true)
         ),
         Some("My Agency Name")
       ).allDeclinedProcessed shouldBe true
 
       ClientConsentsJourneyState(
         Seq(
-          ClientConsent(InvitationId("AG1UGUKTPNJ7W"), expiryDate, Service.MtdIt, consent = false, true),
-          ClientConsent(InvitationId("B9SCS2T4NZBAX"), expiryDate, Service.PersonalIncomeRecord, consent = false, false),
-          ClientConsent(InvitationId("CZTW1KY6RTAAT"), expiryDate, Service.Vat, consent = false, true)
+          ClientConsent(InvitationId("AG1UGUKTPNJ7W"), expiryDate, Service.MtdIt, consent = false, processed = true),
+          ClientConsent(InvitationId("B9SCS2T4NZBAX"), expiryDate, Service.PersonalIncomeRecord, consent = false), // not processed
+          ClientConsent(InvitationId("CZTW1KY6RTAAT"), expiryDate, Service.Vat, consent = false, processed = true)
         ),
         Some("My Agency Name")
       ).allDeclinedProcessed shouldBe true
 
       ClientConsentsJourneyState(
         Seq(
-          ClientConsent(InvitationId("AG1UGUKTPNJ7W"), expiryDate, Service.MtdIt, consent = true, true),
-          ClientConsent(InvitationId("B9SCS2T4NZBAX"), expiryDate, Service.PersonalIncomeRecord, consent = true, true),
-          ClientConsent(InvitationId("CZTW1KY6RTAAT"), expiryDate, Service.Vat, consent = true, true)
+          ClientConsent(InvitationId("AG1UGUKTPNJ7W"), expiryDate, Service.MtdIt, consent = true, processed = true),
+          ClientConsent(InvitationId("B9SCS2T4NZBAX"), expiryDate, Service.PersonalIncomeRecord, consent = true, processed = true),
+          ClientConsent(InvitationId("CZTW1KY6RTAAT"), expiryDate, Service.Vat, consent = true, processed = true)
         ),
         Some("My Agency Name")
       ).allDeclinedProcessed shouldBe false
@@ -57,18 +57,18 @@ class ClientConsentsJourneyStateSpec extends UnitSpec {
     "have allProcessed" in {
       ClientConsentsJourneyState(
         Seq(
-          ClientConsent(InvitationId("AG1UGUKTPNJ7W"), expiryDate, Service.MtdIt, consent = false, true),
-          ClientConsent(InvitationId("B9SCS2T4NZBAX"), expiryDate, Service.PersonalIncomeRecord, consent = true, true),
-          ClientConsent(InvitationId("CZTW1KY6RTAAT"), expiryDate, Service.Vat, consent = true, true)
+          ClientConsent(InvitationId("AG1UGUKTPNJ7W"), expiryDate, Service.MtdIt, consent = false, processed = true),
+          ClientConsent(InvitationId("B9SCS2T4NZBAX"), expiryDate, Service.PersonalIncomeRecord, consent = true, processed = true),
+          ClientConsent(InvitationId("CZTW1KY6RTAAT"), expiryDate, Service.Vat, consent = true, processed = true)
         ),
         Some("My Agency Name")
       ).allProcessed shouldBe true
 
       ClientConsentsJourneyState(
         Seq(
-          ClientConsent(InvitationId("AG1UGUKTPNJ7W"), expiryDate, Service.MtdIt, consent = false, true),
-          ClientConsent(InvitationId("B9SCS2T4NZBAX"), expiryDate, Service.PersonalIncomeRecord, consent = true, false),
-          ClientConsent(InvitationId("CZTW1KY6RTAAT"), expiryDate, Service.Vat, consent = true, true)
+          ClientConsent(InvitationId("AG1UGUKTPNJ7W"), expiryDate, Service.MtdIt, consent = false, processed = true),
+          ClientConsent(InvitationId("B9SCS2T4NZBAX"), expiryDate, Service.PersonalIncomeRecord, consent = true), // not processed
+          ClientConsent(InvitationId("CZTW1KY6RTAAT"), expiryDate, Service.Vat, consent = true, processed = true)
         ),
         Some("My Agency Name")
       ).allProcessed shouldBe false


### PR DESCRIPTION
This was introduced during the last PR https://github.com/hmrc/agent-invitations-frontend/pull/1010 
I’d rather change the URL, but don't want to do that without a heads up for things like PA stats etc. So for now I’m going to preserve the original functionality. 

Ideally we should still try and move away from using 'serviceMessageKey' but to be honest this is probably best looked at for updating how we implement the CYA pattern when we move away from play-fsm.