### PR TITLE
APB-7412 [CS] fix back link without translation

### DIFF
--- a/app/uk/gov/hmrc/agentinvitationsfrontend/views/MainTemplate.scala.html
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/views/MainTemplate.scala.html
@@ -107,6 +107,6 @@
     serviceName = Some(msgs(bannerTitle)),
     pageTitle = Some(title),
     isWelshTranslationAvailable = true,
-    backLink = if(backLinkHref.isDefined) Some(BackLink(href = backLinkHref.get)) else None
+    backLink = if(backLinkHref.isDefined) Some(BackLink.withDefaultText(href = backLinkHref.get)) else None
 ))(mainContentWithHelpLink)
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -14,16 +14,7 @@
 
 include "frontend.conf"
 
-# Provides an implementation of AuditConnector. An audit connector must be provided.
-play.modules.enabled += "uk.gov.hmrc.play.audit.AuditModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
-
-# Provides an implementation of MetricsFilter. Use `uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule` or create your own.
-# A metric filter must be provided
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule"
-
-# Provides an implementation and configures all filters required by a Platform frontend microservice.
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.frontend.FrontendModule"
 play.modules.enabled += "uk.gov.hmrc.mongo.play.PlayMongoModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,11 +3,11 @@ import sbt._
 object AppDependencies {
 
   private val mongoVersion: String = "1.3.0"
-  private val bootstrapVer: String = "7.20.0"
+  private val bootstrapVer: String = "7.22.0"
 
   lazy val compileDeps = Seq(
     "uk.gov.hmrc"        %% "bootstrap-frontend-play-28" % bootstrapVer,
-    "uk.gov.hmrc"        %% "play-frontend-hmrc"         % "7.16.0-play-28",
+    "uk.gov.hmrc"        %% "play-frontend-hmrc"         % "7.23.0-play-28",
     "uk.gov.hmrc"        %% "play-fsm"                   % "0.89.0-play-28",
     "uk.gov.hmrc"        %% "agent-mtd-identifiers"      % "1.13.0",
     "uk.gov.hmrc"        %% "agent-kenshoo-monitoring"   % "5.4.0",


### PR DESCRIPTION
By default BackLink() will say "Back" but it's hardcoded without translation unless using .withDefaultText