### PR TITLE
[CS] a11y fix for no spaces between multiple attributes on links

### DIFF
--- a/app/uk/gov/hmrc/agentinvitationsfrontend/views/components/a.scala.html
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/views/components/a.scala.html
@@ -22,19 +22,12 @@
     classes: Option[String] = None,
     id: Option[String] = None,
     attrs: Map[String, String] = Map.empty,
-    openInNewWindow: Boolean = false,
-    rel: Option[String] = None,
-    target: Option[String] = None,
+    openInNewWindow: Boolean = false
 )(implicit msgs: Messages)
 
     @cls = @{classes.getOrElse("govuk-link govuk-body")}
 
     <a href="@href" class="@cls"
         @if(id.nonEmpty){id="@id"}
-        @if(openInNewWindow){
-            target="_blank" rel="noreferrer noopener"
-        } else{
-            @if(rel.nonEmpty){rel="@rel"}
-            @if(target.nonEmpty){target="@target"}
-        }
-        @attrs.map(a => a._1 + "=" + a._2)>@Html(msgs(key))</a>
+        @if(openInNewWindow){ target="_blank" rel="noreferrer noopener" }
+        @attrs.map(a => a._1 + "=" + a._2 + " ")>@Html(msgs(key))</a>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefac
 resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc"          % "sbt-auto-build"        % "3.14.0")
+addSbtPlugin("uk.gov.hmrc"          % "sbt-auto-build"        % "3.15.0")
 addSbtPlugin("uk.gov.hmrc"          % "sbt-distributables"    % "2.2.0")
 addSbtPlugin("com.typesafe.play"    % "sbt-plugin"            % "2.8.20")
 addSbtPlugin("com.typesafe.sbt"     % "sbt-twirl"             % "1.5.1")


### PR DESCRIPTION
also removes redundant custom rel/target params

something I picked up [here](https://build.tax.service.gov.uk/job/Agents/job/agent-authorisation-a11y-test/814/Accessibility_20Check_20Report/)