### PR TITLE
APB-7569 Confirm-client screen missing in Request IRV auth journey

### DIFF
--- a/app/uk/gov/hmrc/agentinvitationsfrontend/views/agents/ReviewAuthorisationsPageConfig.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/views/agents/ReviewAuthorisationsPageConfig.scala
@@ -32,8 +32,8 @@ case class ReviewAuthorisationsPageConfig(
 
   def clientNameOf(authorisationRequest: AuthorisationRequest, noNameMessage: String): String =
     authorisationRequest.invitation.service match {
-      case Service.PersonalIncomeRecord => noNameMessage
-      case _                            => authorisationRequest.clientName.stripSuffix(".")
+      case Service.PersonalIncomeRecord if authorisationRequest.clientName.isEmpty => noNameMessage
+      case _                                                                       => authorisationRequest.clientName.stripSuffix(".")
     }
 
   val numberOfItems: Int = basket.size


### PR DESCRIPTION
Added IsEmpty condition for PIR cases if the client's name is available  