### PR TITLE
APB-7569 _RW_Confirm-client screen missing in Request IRV auth journey 

### DIFF
--- a/app/uk/gov/hmrc/agentinvitationsfrontend/journeys/AgentInvitationJourneyModel.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/journeys/AgentInvitationJourneyModel.scala
@@ -380,8 +380,7 @@ object AgentInvitationJourneyModel extends JourneyModel with Logging {
                                Invitation(Some(ClientType.Personal), Service.PersonalIncomeRecord, irvClient.nino))
                            }
                            .flatMap { request =>
-                             checkIfPendingOrActiveAndGoto(
-                               ReviewAuthorisations(ClientType.Personal, Services.supportedServicesFor(ClientType.Personal), basket + request))(
+                             checkIfPendingOrActiveAndGoto(ConfirmClient(request, basket))(
                                ClientType.Personal,
                                agent.arn,
                                request,

--- a/app/uk/gov/hmrc/agentinvitationsfrontend/views/agents/ReviewAuthorisationsPageConfig.scala
+++ b/app/uk/gov/hmrc/agentinvitationsfrontend/views/agents/ReviewAuthorisationsPageConfig.scala
@@ -32,8 +32,8 @@ case class ReviewAuthorisationsPageConfig(
 
   def clientNameOf(authorisationRequest: AuthorisationRequest, noNameMessage: String): String =
     authorisationRequest.invitation.service match {
-      case Service.PersonalIncomeRecord => noNameMessage
-      case _                            => authorisationRequest.clientName.stripSuffix(".")
+      case Service.PersonalIncomeRecord if authorisationRequest.clientName.isEmpty => noNameMessage
+      case _                                                                       => authorisationRequest.clientName.stripSuffix(".")
     }
 
   val numberOfItems: Int = basket.size


### PR DESCRIPTION
fix for client's name on invitations/agents/review-authorisations
Added client's confirm page for PIR /agents/confirm-client & Unit Test 